### PR TITLE
Enable read-aloud for continuous responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Transcribe provides real time transcription for microphone and speaker output. I
 - Save chat history
 - Response Audio
 
+Continuous responses can be read aloud automatically by setting `read_continuous_response` to `Yes` in the configuration files.
+
 ## Response Generation ##
 Response generation requires a paid account with an API Key for an OpenAI API compatible provider like 
 OpenAI (**Encouraged**)

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -250,7 +250,14 @@ class GPTResponder:
         if not self.enabled:
             return ''
 
-        return self.generate_response_from_transcript_no_check()
+        response = self.generate_response_from_transcript_no_check()
+
+        if response and self.config['General'].get('read_continuous_response', False):
+            context = self.conversation.context
+            context.set_read_response(True)
+            context.audio_player_var.speech_text_available.set()
+
+        return response
 
     def generate_response_for_selected_text(self, text: str):
         """Ping LLM to get a suggested response right away.

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -81,6 +81,7 @@ General:
   disable_speaker: False
   stt: whisper
   continuous_response: True
+  read_continuous_response: False
   # The interval at which to ping the LLM for response
   llm_response_interval: 10
 

--- a/app/transcribe/tests/test_gpt_responder.py
+++ b/app/transcribe/tests/test_gpt_responder.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import threading
+
+from app.transcribe.gpt_responder import GPTResponder
+
+
+class TestGPTResponderReadContinuous(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            'General': {
+                'llm_response_interval': 1,
+                'chat_inference_provider': 'openai',
+                'read_continuous_response': True
+            },
+            'OpenAI': {
+                'api_key': 'key',
+                'base_url': 'url',
+                'ai_model': 'model',
+                'response_request_timeout_seconds': 10,
+                'summarize_request_timeout_seconds': 30,
+                'temperature': 0.0
+            }
+        }
+
+        self.context = MagicMock()
+        self.context.audio_player_var = MagicMock()
+        self.context.audio_player_var.speech_text_available = threading.Event()
+
+        self.convo = MagicMock()
+        self.convo.context = self.context
+
+        self.responder = GPTResponder(config=self.config, convo=self.convo, file_name='file', save_to_file=False)
+        self.responder.enabled = True
+
+    @patch.object(GPTResponder, 'generate_response_from_transcript_no_check', return_value='hi')
+    def test_read_continuous_response_sets_event(self, mock_gen):
+        self.responder.generate_response_from_transcript()
+        self.context.set_read_response.assert_called_with(True)
+        self.assertTrue(self.context.audio_player_var.speech_text_available.is_set())
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -5,3 +5,5 @@ Default option in Transcribe is to provide responses as text in the response win
 Optionally users can disable continuous responses and get Audio responses in addition to text responses using the Suggest Response and Read button as displayed in the image below.
 
 ![Screenshot](../assets/ReadResponses.png)
+
+To automatically read responses aloud when continuous responses are enabled, set `read_continuous_response` to `Yes` in your `override.yaml` or `parameters.yaml` file.


### PR DESCRIPTION
## Summary
- allow GPTResponder to trigger audio playback when `read_continuous_response` is enabled
- add `read_continuous_response` parameter to configuration
- document new feature in README and SpeechMode guide
- test that reading continuous responses sets the proper events

## Testing
- `pytest -q` *(fails: command not found)*