### PR TITLE
Fix continuous read aloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Transcribe provides real time transcription for microphone and speaker output. I
 - Save chat history
 - Response Audio
 
+Continuous responses and selected-text responses can be read aloud automatically by setting `read_continuous_response` to `Yes` in the configuration files.
+
 ## Response Generation ##
 Response generation requires a paid account with an API Key for an OpenAI API compatible provider like 
 OpenAI (**Encouraged**)

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -250,7 +250,14 @@ class GPTResponder:
         if not self.enabled:
             return ''
 
-        return self.generate_response_from_transcript_no_check()
+        response = self.generate_response_from_transcript_no_check()
+
+        if response and self.config['General'].get('read_continuous_response', False):
+            context = self.conversation.context
+            context.set_read_response(True)
+            context.audio_player_var.speech_text_available.set()
+
+        return response
 
     def generate_response_for_selected_text(self, text: str):
         """Ping LLM to get a suggested response right away.
@@ -306,6 +313,11 @@ class GPTResponder:
         processed_response = collected_messages
 
         self._save_response_to_file(processed_response)
+
+        if self.config['General'].get('read_continuous_response', False):
+            context = self.conversation.context
+            context.set_read_response(True)
+            context.audio_player_var.speech_text_available.set()
 
         return processed_response
 

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -81,6 +81,7 @@ General:
   disable_speaker: False
   stt: whisper
   continuous_response: True
+  read_continuous_response: False
   # The interval at which to ping the LLM for response
   llm_response_interval: 10
 

--- a/app/transcribe/tests/test_gpt_responder.py
+++ b/app/transcribe/tests/test_gpt_responder.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import threading
+
+from app.transcribe.gpt_responder import GPTResponder
+
+
+class TestGPTResponderReadContinuous(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            'General': {
+                'llm_response_interval': 1,
+                'chat_inference_provider': 'openai',
+                'read_continuous_response': True
+            },
+            'OpenAI': {
+                'api_key': 'key',
+                'base_url': 'url',
+                'ai_model': 'model',
+                'response_request_timeout_seconds': 10,
+                'summarize_request_timeout_seconds': 30,
+                'temperature': 0.0
+            }
+        }
+
+        self.context = MagicMock()
+        self.context.audio_player_var = MagicMock()
+        self.context.audio_player_var.speech_text_available = threading.Event()
+
+        self.convo = MagicMock()
+        self.convo.context = self.context
+
+        self.responder = GPTResponder(config=self.config, convo=self.convo, file_name='file', save_to_file=False)
+        self.responder.enabled = True
+
+    @patch.object(GPTResponder, 'generate_response_from_transcript_no_check', return_value='hi')
+    def test_read_continuous_response_sets_event(self, mock_gen):
+        self.responder.generate_response_from_transcript()
+        self.context.set_read_response.assert_called_with(True)
+        self.assertTrue(self.context.audio_player_var.speech_text_available.is_set())
+
+    @patch.object(GPTResponder, '_save_response_to_file')
+    @patch.object(GPTResponder, 'llm_client')
+    def test_generate_response_selected_text_sets_event(self, mock_client, mock_save):
+        stream_chunk = MagicMock()
+        stream_chunk.choices = [MagicMock(delta=MagicMock(content='hi'))]
+        mock_client.chat.completions.create.return_value = [stream_chunk]
+        self.responder.generate_response_for_selected_text('text')
+        self.context.set_read_response.assert_called_with(True)
+        self.assertTrue(self.context.audio_player_var.speech_text_available.is_set())
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -5,3 +5,5 @@ Default option in Transcribe is to provide responses as text in the response win
 Optionally users can disable continuous responses and get Audio responses in addition to text responses using the Suggest Response and Read button as displayed in the image below.
 
 ![Screenshot](../assets/ReadResponses.png)
+
+To automatically read responses aloud when continuous responses or selected-text responses are enabled, set `read_continuous_response` to `Yes` in your `override.yaml` or `parameters.yaml` file.


### PR DESCRIPTION
## Summary
- enable reading aloud for responses from selected text
- add tests to cover selected-text read events
- document that selected responses will also be read automatically

## Testing
- `python - <<'PY'` ... `unittest.main()`