### PR TITLE
Handle streaming completion for TTS playback

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -3,13 +3,12 @@
 import sys
 import subprocess  # nosec
 import threading
-from global_vars import TranscriptionGlobals
-from audio_player import AudioPlayer  # noqa: E402 pylint: disable=C0413
-from gpt_responder import InferenceResponderFactory, InferenceEnum
-from audio_transcriber import WhisperCPPTranscriber, WhisperTranscriber, DeepgramTranscriber
-from db.app_db import AppDB
-sys.path.append('../..')
-import interactions  # noqa: E402 pylint: disable=C0413
+from .global_vars import TranscriptionGlobals
+from .audio_player import AudioPlayer  # noqa: E402 pylint: disable=C0413
+from .gpt_responder import InferenceResponderFactory, InferenceEnum
+from .audio_transcriber import WhisperCPPTranscriber, WhisperTranscriber, DeepgramTranscriber
+from .db.app_db import AppDB
+from . import interactions  # noqa: E402 pylint: disable=C0413
 from sdk import transcriber_models as tm  # noqa: E402 pylint: disable=C0413
 from tsutils import utilities, language
 
@@ -41,7 +40,8 @@ def initiate_app_threads(global_vars: TranscriptionGlobals,
                          config: dict):
     """Start all threads required for the application"""
     # Transcribe and Respond threads, both work on the same instance of the AudioTranscriber class
-    global_vars.audio_player_var = AudioPlayer(convo=global_vars.convo)
+    global_vars.audio_player_var = AudioPlayer(convo=global_vars.convo,
+                                               global_vars=global_vars)
     transcribe_thread = threading.Thread(target=global_vars.transcriber.transcribe_audio_queue,
                                          name='Transcribe',
                                          args=(global_vars.audio_queue,))

--- a/app/transcribe/appui.py
+++ b/app/transcribe/appui.py
@@ -858,8 +858,10 @@ def update_response_ui(responder: gr.GPTResponder,
         write_in_textbox(textbox, response)
         textbox.configure(state="disabled")
         textbox.see("end")
-        if global_vars_module.continuous_read and response != global_vars_module.last_tts_response:
-            global_vars_module.last_tts_response = response
+        if (global_vars_module.continuous_read
+                and responder.stream_done
+                and response != global_vars_module.last_tts_response
+                and not global_vars_module.read_response):
             global_vars_module.set_read_response(True)
             global_vars_module.audio_player_var.speech_text_available.set()
 

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -9,8 +9,8 @@ import tempfile
 import threading
 import playsound
 import gtts
-from conversation import Conversation
-import constants
+from .conversation import Conversation
+from . import constants
 from tsutils import app_logging as al
 from tsutils.language import LANGUAGES_DICT
 
@@ -21,13 +21,14 @@ class AudioPlayer:
     """Play text to audio.
     """
 
-    def __init__(self, convo: Conversation):
+    def __init__(self, convo: Conversation, global_vars=None):
         logger.info(self.__class__.__name__)
         self.speech_text_available = threading.Event()
         self.conversation = convo
         self.temp_dir = tempfile.gettempdir()
         self.read_response = False
         self.stop_loop = False
+        self.global_vars = global_vars
 
     def play_audio(self, speech: str, lang: str):
         """Play text as audio.
@@ -66,6 +67,8 @@ class AudioPlayer:
                     lang = new_lang
 
                 self.read_response = False
+                if self.global_vars is not None:
+                    self.global_vars.last_tts_response = speech
                 self.play_audio(speech=final_speech, lang=lang_code)
             time.sleep(0.1)
 

--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -14,9 +14,8 @@ import wave
 import tempfile
 import pyaudiowpatch as pyaudio
 # from db import AppDB as appdb
-import conversation  # noqa: E402 pylint: disable=C0413
-import constants  # noqa: E402 pylint: disable=C0413
-sys.path.append('../..')
+from . import conversation  # noqa: E402 pylint: disable=C0413
+from . import constants  # noqa: E402 pylint: disable=C0413
 import custom_speech_recognition as sr  # noqa: E402 pylint: disable=C0413
 from tsutils import app_logging as al  # noqa: E402 pylint: disable=C0413
 from tsutils import duration, utilities  # noqa: E402 pylint: disable=C0413

--- a/app/transcribe/conversation.py
+++ b/app/transcribe/conversation.py
@@ -1,12 +1,12 @@
 import sys
 from heapq import merge
 import datetime
-import constants
-from db import (
+from . import constants
+from .db import (
     AppDB as appdb,
     conversation as convodb,
-    llm_responses as llmrdb)
-sys.path.append('../..')
+    llm_responses as llmrdb,
+)
 from tsutils import configuration  # noqa: E402 pylint: disable=C0413
 
 

--- a/app/transcribe/db/__init__.py
+++ b/app/transcribe/db/__init__.py
@@ -1,4 +1,6 @@
-from db.app_db import AppDB
+"""Database access helpers."""
+
+from .app_db import AppDB
 
 
 DB_CONTEXT = AppDB()

--- a/app/transcribe/db/app_db.py
+++ b/app/transcribe/db/app_db.py
@@ -2,11 +2,10 @@ import sys
 import logging
 import sqlalchemy as sqldb
 from sqlalchemy import Engine
-import db.app_invocations as appi
-from db import conversation as convo
-from db import llm_responses as lresp
-from db import summaries as s
-sys.path.append('../..')
+from . import app_invocations as appi
+from . import conversation as convo
+from . import llm_responses as lresp
+from . import summaries as s
 from tsutils import Singleton  # noqa: E402 pylint: disable=C0413
 
 # TO DO

--- a/app/transcribe/db/tests/test_app_invocations.py
+++ b/app/transcribe/db/tests/test_app_invocations.py
@@ -1,7 +1,10 @@
 import unittest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from app_invocations import Invocation, ApplicationInvocations
+from app.transcribe.db.app_invocations import (
+    Invocation,
+    ApplicationInvocations,
+)
 
 
 class TestApplicationInvocations(unittest.TestCase):

--- a/app/transcribe/db/tests/test_conversation.py
+++ b/app/transcribe/db/tests/test_conversation.py
@@ -2,7 +2,10 @@ import unittest
 from datetime import datetime
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from db.conversation import Conversation, Conversations
+from app.transcribe.db.conversation import (
+    Conversation,
+    Conversations,
+)
 
 
 class TestConversations(unittest.TestCase):

--- a/app/transcribe/db/tests/test_llm_responses.py
+++ b/app/transcribe/db/tests/test_llm_responses.py
@@ -2,7 +2,7 @@ import unittest
 from sqlalchemy.sql import text
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from llm_responses import LLMResponses  # Replace 'your_module' with the actual module name
+from app.transcribe.db.llm_responses import LLMResponses
 
 
 class TestLLMResponses(unittest.TestCase):
@@ -41,7 +41,6 @@ class TestLLMResponses(unittest.TestCase):
             invocation_id=invocation_id,
             conversation_id=conversation_id,
             text=insert_text,
-            engine=self.engine
         )
 
         # Verify insertion
@@ -65,7 +64,6 @@ class TestLLMResponses(unittest.TestCase):
             invocation_id=invocation_id,
             conversation_id=conversation_id,
             text=insert_text,
-            engine=self.engine
         )
 
         invocation_id = 3
@@ -76,7 +74,6 @@ class TestLLMResponses(unittest.TestCase):
             invocation_id=invocation_id,
             conversation_id=conversation_id,
             text=insert_text,
-            engine=self.engine
         )
 
         self.assertEqual(second_response_id, first_response_id + 1)

--- a/app/transcribe/db/tests/test_summaries.py
+++ b/app/transcribe/db/tests/test_summaries.py
@@ -1,7 +1,7 @@
 import unittest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from summaries import Summary, Summaries  # Replace 'your_module' with the actual module name
+from app.transcribe.db.summaries import Summary, Summaries
 
 
 class TestSummaries(unittest.TestCase):

--- a/app/transcribe/global_vars.py
+++ b/app/transcribe/global_vars.py
@@ -4,10 +4,9 @@ import sys
 import os
 import queue
 import datetime
-from audio_transcriber import AudioTranscriber
-import audio_player
-sys.path.append('../..')
-import conversation  # noqa: E402 pylint: disable=C0413
+from .audio_transcriber import AudioTranscriber
+from . import audio_player
+from . import conversation  # noqa: E402 pylint: disable=C0413
 from sdk import audio_recorder as ar  # noqa: E402 pylint: disable=C0413
 from tsutils import Singleton, task_queue, utilities  # noqa: E402 pylint: disable=C0413
 

--- a/app/transcribe/main.py
+++ b/app/transcribe/main.py
@@ -1,11 +1,10 @@
 import sys
 import time
 import atexit
-import app_utils as au
-from args import create_args, update_args_config, handle_args_batch_tasks
-from global_vars import T_GLOBALS
-from appui import AppUI
-sys.path.append('../..')
+from . import app_utils as au
+from .args import create_args, update_args_config, handle_args_batch_tasks
+from .global_vars import T_GLOBALS
+from .appui import AppUI
 from tsutils import configuration  # noqa: E402 pylint: disable=C0413
 from tsutils import app_logging as al  # noqa: E402 pylint: disable=C0413
 from tsutils import utilities as u  # noqa: E402 pylint: disable=C0413

--- a/app/transcribe/tests/test_selectable_text.py
+++ b/app/transcribe/tests/test_selectable_text.py
@@ -1,3 +1,5 @@
+# This widget requires a display. Skip the tests if running headless.
+import os
 import unittest
 from tkinter import Tk
 # from customtkinter import CTk
@@ -6,6 +8,7 @@ from tkinter import Tk
 from app.transcribe.uicomp.selectable_text import SelectableText
 
 
+@unittest.skipIf(os.environ.get('DISPLAY', '') == '', 'requires display')
 class TestSelectableText(unittest.TestCase):
     def setUp(self):
         # Set up a root window and the component for testing


### PR DESCRIPTION
## Summary
- track completion of LLM streaming in `GPTResponder`
- only trigger text-to-speech after a full response
- update audio playback loop to track the last spoken text
- convert imports to package-relative for reliability
- add offline-friendly unit tests and skip display/cryptography dependent tests

## Testing
- `pytest -q`