### PR TITLE
Mock recognizer network calls in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests tsutils/tests

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -9,6 +9,28 @@ from unittest.mock import patch
 
 
 class TestRecognition(unittest.TestCase):
+    def fake_google(self, audio, language="en-US", *args, **kwargs):
+        if language.startswith("fr"):
+            return "et c'est la dictée numéro 1"
+        if language.startswith("zh"):
+            return "砸自己的脚"
+        return "1 2"
+
+    def fake_bing(self, audio, key=None, language="en-US", *args, **kwargs):
+        if language.startswith("fr"):
+            return "Essaye la dictée numéro un."
+        if language.startswith("zh"):
+            return "砸自己的脚。"
+        return "123."
+
+    def fake_whisper(self, audio, language="english", *args, **kwargs):
+        lang = language.lower()
+        if lang.startswith("french"):
+            return " et c'est la dictée numéro 1."
+        if lang.startswith("chinese"):
+            return "砸自己的腳"
+        return " 1, 2, 3."
+
     def setUp(self):
         self.AUDIO_FILE_EN = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                           "english.wav")
@@ -18,21 +40,30 @@ class TestRecognition(unittest.TestCase):
                                           "chinese.flac")
         self.WHISPER_CONFIG = {"temperature": 0}
 
+        patches = [
+            patch('custom_speech_recognition.Recognizer.recognize_google', side_effect=self.fake_google),
+            patch('custom_speech_recognition.Recognizer.recognize_whisper', side_effect=self.fake_whisper),
+            patch('custom_speech_recognition.Recognizer.recognize_wit', return_value="one two three"),
+            patch('custom_speech_recognition.Recognizer.recognize_bing', side_effect=self.fake_bing),
+            patch('custom_speech_recognition.Recognizer.recognize_houndify', return_value="one two three"),
+        ]
+        self.patchers = [p.start() for p in patches]
+        for p in patches:
+            self.addCleanup(p.stop)
+
 #    def test_sphinx_english(self):
 #        r = sr.Recognizer()
 #        with sr.AudioFile(self.AUDIO_FILE_EN) as source: audio = r.record(source)
 #        self.assertEqual(r.recognize_sphinx(audio), "one two three")
 
-    @patch('custom_speech_recognition.Recognizer.recognize_google', return_value="1 2")
-    def test_google_english(self, mock_google):
+    def test_google_english(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_EN) as source:
             audio = r.record(source)
         result = r.recognize_google(audio)
         self.assertIn(result, ["1 2"], f'Expected ["1 2"] got {result}')
 
-    @patch('custom_speech_recognition.Recognizer.recognize_google', return_value="et c'est la dictée numéro 1")
-    def test_google_french(self, mock_google):
+    def test_google_french(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_FR) as source:
             audio = r.record(source)
@@ -114,23 +145,20 @@ class TestRecognition(unittest.TestCase):
     #         audio = r.record(source)
     #     self.assertEqual(r.recognize_ibm(audio, username=os.environ["IBM_USERNAME"], password=os.environ["IBM_PASSWORD"], language="zh-CN"), "砸 自己 的 脚 ")
 
-    @patch('custom_speech_recognition.Recognizer.recognize_whisper', return_value=" 1, 2, 3.")
-    def test_whisper_english(self, mock_whisper):
+    def test_whisper_english(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_EN) as source:
             audio = r.record(source)
         self.assertEqual(r.recognize_whisper(audio, language="english", **self.WHISPER_CONFIG), " 1, 2, 3.")
 
-    @patch('custom_speech_recognition.Recognizer.recognize_whisper', return_value=" et c'est la dictée numéro 1.")
-    def test_whisper_french(self, mock_whisper):
+    def test_whisper_french(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_FR) as source:
             audio = r.record(source)
         self.assertEqual(r.recognize_whisper(audio, language="french", **self.WHISPER_CONFIG),
                          " et c'est la dictée numéro 1.")
 
-    @patch('custom_speech_recognition.Recognizer.recognize_whisper', return_value="砸自己的腳")
-    def test_whisper_chinese(self, mock_whisper):
+    def test_whisper_chinese(self):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_ZH) as source:
             audio = r.record(source)


### PR DESCRIPTION
## Summary
- patch speech recognizer methods using unittest.mock
- add pytest config to ignore app/ and example tests

## Testing
- `pytest -q`