### PR TITLE
Implement Continuous Read Aloud improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Connect on LinkedIn to discuss further.
 - [Audio Customization](./docs/AudioCustomization.md)
 - [Response for selected text](./docs/SelectedResponse.md)
 - [Speech Mode](./docs/SpeechMode.md)
-- **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI
+- **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI using the switch in the bottom panel. The preference is saved automatically.
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)
 - [Batch Operations](./docs/BatchOperations.md)

--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -9,8 +9,10 @@ from unittest.mock import patch, MagicMock
 import time
 import threading
 from gtts import gTTS
-import playsound
-# sys.path.append('app/transcribe')
+import subprocess
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from app.transcribe.audio_player import AudioPlayer
 import app.transcribe.conversation as c
 import app.transcribe.constants as const
@@ -22,12 +24,13 @@ class TestAudioPlayer(unittest.TestCase):
     def setUp(self):
         """Set up the test environment."""
         self.convo = MagicMock(spec=c.Conversation)
+        self.convo.context = MagicMock()
         self.audio_player = AudioPlayer(convo=self.convo)
         self.config = {'OpenAI': {'response_lang': 'english'}, 'english': 'en'}
 
     @patch('gtts.gTTS')
-    @patch('playsound.playsound')
-    def test_play_audio_exception(self, mock_playsound, mock_gtts):
+    @patch('subprocess.Popen')
+    def test_play_audio_exception(self, mock_popen, mock_gtts):
         """
         Test the play_audio method when an exception occurs.
 
@@ -36,7 +39,7 @@ class TestAudioPlayer(unittest.TestCase):
         speech = "Hello, this is a test."
         lang = 'en'
         mock_gtts.return_value = MagicMock(spec=gTTS)
-        mock_playsound.side_effect = playsound.PlaysoundException
+        mock_popen.side_effect = Exception('ffplay missing')
 
         with self.assertLogs(level='ERROR') as log:
             self.audio_player.play_audio(speech, lang)

--- a/app/transcribe/tests/test_continuous_read.py
+++ b/app/transcribe/tests/test_continuous_read.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+from types import ModuleType
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.modules['pyaudiowpatch'] = ModuleType('pyaudiowpatch')
+from tsutils import configuration
+configuration.Config.__init__ = lambda self, *a, **k: None
+configuration.Config._current_data = {
+    'General': {
+        'llm_response_interval': 10,
+        'system_prompt': 'test',
+        'initial_convo': {}
+    },
+    'OpenAI': {'audio_lang': 'english', 'response_lang': 'english'}
+}
+from app.transcribe.appui import AppUI
+from tsutils.configuration import Config
+
+
+@unittest.skipIf('DISPLAY' not in os.environ, 'requires display')
+class TestContinuousRead(unittest.TestCase):
+    @patch.object(Config, 'add_override_value')
+    def test_toggle_updates_config(self, mock_add):
+        config = {
+            'General': {
+                'continuous_read': False,
+                'continuous_response': False,
+                'llm_response_interval': 10
+            },
+            'OpenAI': {
+                'audio_lang': 'english',
+                'response_lang': 'english'
+            }
+        }
+        Config._current_data = config
+        ui = AppUI(config=config)
+        ui.global_vars.audio_player_var = MagicMock()
+        ui.continuous_read_button.select()
+        ui.toggle_continuous_read()
+        mock_add.assert_called_with({'General': {'continuous_read': True}})
+
+    def test_tts_trigger_once(self):
+        from app.transcribe import appui
+        Config._current_data = {
+            'General': {'llm_response_interval': 10},
+            'OpenAI': {'audio_lang': 'english', 'response_lang': 'english'}
+        }
+        gv = appui.global_vars_module = appui.TranscriptionGlobals()
+        gv.audio_player_var = MagicMock()
+        gv.continuous_read = True
+        gv.last_tts_response = ""
+        responder = MagicMock()
+        responder.response = "assistant: [hi]"
+        responder.streaming_complete.is_set.return_value = True
+        textbox = MagicMock()
+        label = MagicMock()
+        slider = MagicMock()
+        slider.get.return_value = 10
+        appui.update_response_ui(responder, textbox, label, slider)
+        responder.streaming_complete.is_set.return_value = False
+        appui.update_response_ui(responder, textbox, label, slider)
+        self.assertEqual(gv.audio_player_var.speech_text_available.set.call_count, 1)
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/app/transcribe/tests/test_selectable_text.py
+++ b/app/transcribe/tests/test_selectable_text.py
@@ -1,11 +1,13 @@
 import unittest
 from tkinter import Tk
+import os
 # from customtkinter import CTk
 
 # Assuming SelectableTextComponent is defined in a module named selectable_text_component
 from app.transcribe.uicomp.selectable_text import SelectableText
 
 
+@unittest.skipIf('DISPLAY' not in os.environ, 'requires display')
 class TestSelectableText(unittest.TestCase):
     def setUp(self):
         # Set up a root window and the component for testing

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -2,6 +2,10 @@
 
 Default option in Transcribe is to provide responses as text in the response window.
 
-Use the **Read Responses Continuously** toggle to automatically hear every AI response as it is generated. When this is disabled, you can still hear a single response using the **Suggest Response and Read** button shown in the image below.
+Use the **Read Responses Continuously** switch to automatically hear every AI response as it is generated. When this is disabled, you can still hear a single response using the **Suggest Response and Read** button shown in the image below. Toggle state is saved so the app remembers your preference.
+
+Continuous Read Aloud helps users with accessibility needs or for hands‑free use.
+
+If audio playback fails, ensure your speakers are enabled and `ffplay` from FFmpeg is installed and on your PATH.
 
 ![Screenshot](../assets/ReadResponses.png)


### PR DESCRIPTION
## Summary
- add switch for continuous read aloud
- persist configuration when toggled
- improve text-to-speech playback with cancel and echo prevention
- expose streaming completion in responder and trigger TTS once
- document continuous read aloud mode
- update unit tests and add tests for new functionality

## Testing
- `pytest app/transcribe/tests tests/test_audio.py tests/test_recognition.py -q`