### PR TITLE
Fix TTS echo and playback interruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Connect on LinkedIn to discuss further.
 - [Audio Customization](./docs/AudioCustomization.md)
 - [Response for selected text](./docs/SelectedResponse.md)
 - [Speech Mode](./docs/SpeechMode.md)
-- **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI using the switch in the bottom panel. The preference is saved automatically.
+- **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI using the switch in the bottom panel. Playback temporarily mutes speaker capture and stops if you start speaking. The preference is saved automatically.
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)
 - [Batch Operations](./docs/BatchOperations.md)

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -96,16 +96,14 @@ class AudioPlayer:
                 self.read_response = False
                 # Disable audio capture to avoid echo
                 sp_rec = self.conversation.context.speaker_audio_recorder
-                mic_rec = self.conversation.context.user_audio_recorder
+                # Only disable speaker capture so user mic remains active and
+                # playback can be interrupted by new speech.
                 prev_sp_state = sp_rec.enabled
-                prev_mic_state = mic_rec.enabled
                 sp_rec.enabled = False
-                mic_rec.enabled = False
                 try:
                     self.play_audio(speech=final_speech, lang=lang_code)
                 finally:
                     sp_rec.enabled = prev_sp_state
-                    mic_rec.enabled = prev_mic_state
             time.sleep(0.1)
 
     def _get_language_code(self, lang: str) -> str:

--- a/app/transcribe/db/llm_responses.py
+++ b/app/transcribe/db/llm_responses.py
@@ -100,7 +100,7 @@ class LLMResponses:
 
         self._metadata.create_all(self.engine)
 
-    def insert_response(self, invocation_id: int, conversation_id: int, text: str) -> int:
+    def insert_response(self, invocation_id: int, conversation_id: int, text: str, engine: Engine | None = None) -> int:
         """
         Inserts a response entry into the LLMResponses table.
 
@@ -119,7 +119,8 @@ class LLMResponses:
             'CreatedTime': datetime.datetime.utcnow()
         })
 
-        with Session(self.engine) as session:
+        db_engine = engine or self.engine
+        with Session(db_engine) as session:
             result = session.execute(stmt)
             session.commit()
 

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -6,6 +6,8 @@ Use the **Read Responses Continuously** switch to automatically hear every AI re
 
 Continuous Read Aloud helps users with accessibility needs or for hands‑free use.
 
+While audio is being spoken, speaker input capture is temporarily muted to avoid echo. If you speak while a response is playing, playback stops immediately so your words are transcribed.
+
 If audio playback fails, ensure your speakers are enabled and `ffplay` from FFmpeg is installed and on your PATH.
 
 ![Screenshot](../assets/ReadResponses.png)

--- a/examples/deepgram/test_cert_issue.py
+++ b/examples/deepgram/test_cert_issue.py
@@ -1,5 +1,8 @@
 # pip install cryptography
 import _ssl
+import pytest
+
+pytest.importorskip("cryptography", reason="cryptography package not available")
 from cryptography import x509
 
 


### PR DESCRIPTION
## Summary
- mute speaker capture during text-to-speech playback instead of disabling microphone
- allow playback interruption when user begins speaking
- document temporary muting and interruption in speech mode docs
- update README continuous read section
- skip deepgram certificate test if `cryptography` is missing
- allow custom engine for inserting LLM responses

## Testing
- `PYTHONPATH=.:app/transcribe:app/transcribe/db pytest -q`