### PR TITLE
Fix TTS echo capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Connect on LinkedIn to discuss further.
 - [Response for selected text](./docs/SelectedResponse.md)
 - [Speech Mode](./docs/SpeechMode.md)
 - **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI using the switch in the bottom panel. Playback temporarily mutes speaker capture and stops if you start speaking. The preference is saved automatically.
+- Automatic echo suppression prevents the AI from responding to its own speech.
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)
 - [Batch Operations](./docs/BatchOperations.md)

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -8,6 +8,7 @@ import time
 import tempfile
 import threading
 import subprocess
+import datetime
 import playsound
 import gtts
 from conversation import Conversation
@@ -103,7 +104,9 @@ class AudioPlayer:
                 try:
                     self.play_audio(speech=final_speech, lang=lang_code)
                 finally:
+                    time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
                     sp_rec.enabled = prev_sp_state
+                    self.conversation.context.last_playback_end = datetime.datetime.utcnow()
             time.sleep(0.1)
 
     def _get_language_code(self, lang: str) -> str:

--- a/app/transcribe/constants.py
+++ b/app/transcribe/constants.py
@@ -9,3 +9,8 @@ PERSONA_SPEAKER = 'Speaker'
 LOG_NAME = 'Transcribe'
 MAX_TRANSCRIPTION_PHRASES_FOR_LLM = 100
 TRANSCRIPT_UI_UPDATE_DELAY_DURATION_MS = 500
+
+# Delay before re-enabling speaker capture after TTS playback stops
+SPEAKER_REENABLE_DELAY_SECONDS = 0.3
+# Window after playback during which identical speaker input is ignored
+PLAYBACK_IGNORE_WINDOW_SECONDS = 1.0

--- a/app/transcribe/global_vars.py
+++ b/app/transcribe/global_vars.py
@@ -32,6 +32,8 @@ class TranscriptionGlobals(Singleton.Singleton):
     continuous_read: bool = False
     # Last response that was read aloud
     last_tts_response: str = ""
+    # Timestamp when the last TTS playback finished
+    last_playback_end: datetime.datetime = None
     # LLM Response to an earlier conversation
     # This is populated when user clicks on text in transcript textbox
     previous_response: str = None
@@ -79,6 +81,7 @@ class TranscriptionGlobals(Singleton.Singleton):
         self.db_context['db_log_file'] = db_log_file
         self.continuous_read = False
         self.last_tts_response = ""
+        self.last_playback_end = None
         self._initialized = True
 
     def set_transcriber(self, transcriber):

--- a/app/transcribe/tests/test_audio_transcriber.py
+++ b/app/transcribe/tests/test_audio_transcriber.py
@@ -1,0 +1,55 @@
+import unittest
+import datetime
+import sys
+import os
+from types import ModuleType
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+sys.modules['pyaudiowpatch'] = ModuleType('pyaudiowpatch')
+
+from app.transcribe.audio_transcriber import AudioTranscriber
+import app.transcribe.constants as const
+
+class DummyTranscriber(AudioTranscriber):
+    def check_for_latency(self, results):
+        return False, 0, 0
+
+    def prune_for_latency(self, who_spoke, original_data_size, results, prune_id, file_path, prune_percent):
+        return '', ''
+
+class TestAudioTranscriber(unittest.TestCase):
+    def setUp(self):
+        mic = MagicMock()
+        mic.SAMPLE_RATE = 16000
+        mic.SAMPLE_WIDTH = 2
+        mic.channels = 1
+        speaker = MagicMock()
+        speaker.SAMPLE_RATE = 16000
+        speaker.SAMPLE_WIDTH = 2
+        speaker.channels = 1
+        model = MagicMock()
+        convo = MagicMock()
+        convo.context = MagicMock()
+        config = {
+            'General': {
+                'clear_transcript_periodically': False,
+                'clear_transcript_interval_seconds': 10
+            }
+        }
+        self.transcriber = DummyTranscriber(mic, speaker, model, convo, config)
+
+    def test_should_ignore_recent_tts(self):
+        gv = self.transcriber.conversation.context
+        gv.last_tts_response = 'hello world'
+        gv.last_playback_end = datetime.datetime.utcnow()
+        self.assertTrue(self.transcriber._should_ignore_speaker_transcript('hello world'))
+
+    def test_not_ignore_when_old(self):
+        gv = self.transcriber.conversation.context
+        gv.last_tts_response = 'hello world'
+        gv.last_playback_end = datetime.datetime.utcnow() - datetime.timedelta(seconds=5)
+        self.assertFalse(self.transcriber._should_ignore_speaker_transcript('hello world'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -7,6 +7,7 @@ Use the **Read Responses Continuously** switch to automatically hear every AI re
 Continuous Read Aloud helps users with accessibility needs or for hands‑free use.
 
 While audio is being spoken, speaker input capture is temporarily muted to avoid echo. If you speak while a response is playing, playback stops immediately so your words are transcribed.
+To fully eliminate echo, capture resumes only after a brief delay and any input matching the last spoken response within one second is ignored.
 
 If audio playback fails, ensure your speakers are enabled and `ffplay` from FFmpeg is installed and on your PATH.
 


### PR DESCRIPTION
## Summary
- delay re-enabling speaker capture after TTS playback ends
- ignore speaker transcription that matches the just-played response
- track last playback timestamp
- document echo suppression
- test `_should_ignore_speaker_transcript`

## Testing
- `pytest app/transcribe/db/tests/test_app_invocations.py -q`
- `pytest app/transcribe/db/tests/test_llm_responses.py -q`
- `pytest app/transcribe/db/tests/test_conversation.py -q`
- `pytest app/transcribe/db/tests/test_summaries.py -q`
- `pytest app/transcribe/tests/test_audio_player.py -q`
- `pytest app/transcribe/tests/test_audio_transcriber.py -q`
- `pytest app/transcribe/tests/test_selectable_text.py -q`
- `pytest app/transcribe/tests/test_continuous_read.py -q` *(skipped)*