### PR TITLE
Fix repeated TTS playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Connect on LinkedIn to discuss further.
 - [Speech Mode](./docs/SpeechMode.md)
 - **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI using the switch in the bottom panel. Playback temporarily mutes speaker capture and stops if you start speaking. The preference is saved automatically.
 - Automatic echo suppression prevents the AI from responding to its own speech.
+- Spoken replies never repeat&mdash;only the newest answer is read aloud.
 - Configure TTS speed via `tts_speech_rate` in `parameters.yaml`.
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -114,7 +114,9 @@ class AudioPlayer:
                     sp_rec.enabled = prev_sp_state
                     gv = self.conversation.context
                     gv.last_playback_end = datetime.datetime.utcnow()
-                    gv.last_spoken_response = ""
+                    # Keep last_spoken_response so update_response_ui
+                    # can detect when a new response is generated and
+                    # avoid replaying the same audio multiple times.
             time.sleep(0.1)
 
     def _get_language_code(self, lang: str) -> str:

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -7,7 +7,7 @@ Use the **Read Responses Continuously** switch to automatically hear every AI re
 Continuous Read Aloud helps users with accessibility needs or for hands‑free use.
 
 While audio is being spoken, speaker input capture is temporarily muted to avoid echo. If you speak while a response is playing, playback stops immediately so your words are transcribed.
-To fully eliminate echo, capture resumes only after a brief delay and any input similar to the last spoken response within two seconds is ignored.
+To fully eliminate echo, capture resumes only after a brief delay and any input similar to the last spoken response within two seconds is ignored. After playback ends, the last response is retained so it won't be read again until a new answer is produced.
 
 If audio playback fails, ensure your speakers are enabled and `ffplay` from FFmpeg is installed and on your PATH.
 


### PR DESCRIPTION
## Summary
- keep last spoken response after playback ends
- document fix to prevent repeated audio
- update speech mode docs

## Testing
- `PYTHONPATH=. pytest -q`