### PR TITLE
Fix repeated TTS playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Connect on LinkedIn to discuss further.
 - [Speech Mode](./docs/SpeechMode.md)
 - **New:** Toggle [Continuous Read Aloud](./docs/SpeechMode.md#speech-mode) from the UI using the switch in the bottom panel. Playback temporarily mutes speaker capture and stops if you start speaking. The preference is saved automatically.
 - Automatic echo suppression prevents the AI from responding to its own speech.
+- Spoken replies never repeat&mdash;only the newest answer is read aloud.
 - Configure TTS speed via `tts_speech_rate` in `parameters.yaml`.
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -114,7 +114,9 @@ class AudioPlayer:
                     sp_rec.enabled = prev_sp_state
                     gv = self.conversation.context
                     gv.last_playback_end = datetime.datetime.utcnow()
-                    gv.last_spoken_response = ""
+                    # Keep last_spoken_response so update_response_ui
+                    # can detect when a new response is generated and
+                    # avoid replaying the same audio multiple times.
             time.sleep(0.1)
 
     def _get_language_code(self, lang: str) -> str:

--- a/app/transcribe/db/__init__.py
+++ b/app/transcribe/db/__init__.py
@@ -1,4 +1,14 @@
-from .app_db import AppDB
+"""Database package initialization with path adjustments."""
+from __future__ import annotations
+
+import os
+import sys
+
+PARENT_DIR = os.path.dirname(os.path.dirname(__file__))
+if PARENT_DIR not in sys.path:
+    sys.path.insert(0, PARENT_DIR)
+
+from db.app_db import AppDB
 
 
 DB_CONTEXT = AppDB()

--- a/app/transcribe/db/app_db.py
+++ b/app/transcribe/db/app_db.py
@@ -2,10 +2,10 @@ import sys
 import logging
 import sqlalchemy as sqldb
 from sqlalchemy import Engine
-from . import app_invocations as appi
-from . import conversation as convo
-from . import llm_responses as lresp
-from . import summaries as s
+import db.app_invocations as appi
+from db import conversation as convo
+from db import llm_responses as lresp
+from db import summaries as s
 sys.path.append('../..')
 from tsutils import Singleton  # noqa: E402 pylint: disable=C0413
 

--- a/app/transcribe/db/tests/test_app_invocations.py
+++ b/app/transcribe/db/tests/test_app_invocations.py
@@ -1,7 +1,10 @@
 import unittest
+import os
+import sys
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from app.transcribe.db.app_invocations import Invocation, ApplicationInvocations
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from db.app_invocations import Invocation, ApplicationInvocations
 
 
 class TestApplicationInvocations(unittest.TestCase):

--- a/app/transcribe/db/tests/test_conversation.py
+++ b/app/transcribe/db/tests/test_conversation.py
@@ -1,8 +1,11 @@
 import unittest
 from datetime import datetime
+import os
+import sys
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from app.transcribe.db.conversation import Conversation, Conversations
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from db.conversation import Conversation, Conversations
 
 
 class TestConversations(unittest.TestCase):

--- a/app/transcribe/db/tests/test_llm_responses.py
+++ b/app/transcribe/db/tests/test_llm_responses.py
@@ -1,8 +1,11 @@
 import unittest
+import os
+import sys
 from sqlalchemy.sql import text
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from app.transcribe.db.llm_responses import LLMResponses
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from db.llm_responses import LLMResponses
 
 
 class TestLLMResponses(unittest.TestCase):

--- a/app/transcribe/db/tests/test_summaries.py
+++ b/app/transcribe/db/tests/test_summaries.py
@@ -1,7 +1,10 @@
 import unittest
+import os
+import sys
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
-from app.transcribe.db.summaries import Summary, Summaries
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+from db.summaries import Summary, Summaries
 
 
 class TestSummaries(unittest.TestCase):

--- a/docs/SpeechMode.md
+++ b/docs/SpeechMode.md
@@ -7,7 +7,7 @@ Use the **Read Responses Continuously** switch to automatically hear every AI re
 Continuous Read Aloud helps users with accessibility needs or for hands‑free use.
 
 While audio is being spoken, speaker input capture is temporarily muted to avoid echo. If you speak while a response is playing, playback stops immediately so your words are transcribed.
-To fully eliminate echo, capture resumes only after a brief delay and any input similar to the last spoken response within two seconds is ignored.
+To fully eliminate echo, capture resumes only after a brief delay and any input similar to the last spoken response within two seconds is ignored. After playback ends, the last response is retained so it won't be read again until a new answer is produced.
 
 If audio playback fails, ensure your speakers are enabled and `ffplay` from FFmpeg is installed and on your PATH.
 


### PR DESCRIPTION
## Summary
- keep last spoken response after playback ends
- document fix to prevent repeated audio
- update speech mode docs
- restore absolute imports and update tests

## Testing
- `PYTHONPATH=. pytest -q`
- `python app/transcribe/main.py --help` *(fails: No module named 'pyaudiowpatch')*