### PR TITLE
Fix WhisperCpp model selection

### DIFF
--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -150,7 +150,7 @@ def create_transcriber(
             config=config)
     elif name.lower() == 'whisper.cpp':
         stt_model_config: dict = {
-            'local_transcripton_model_file': 'ggml-' + config['WhisperCpp']['local_transcripton_model_file'],
+            'local_transcription_model_file': 'ggml-' + config['WhisperCpp']['local_transcription_model_file'],
             'audio_lang': get_language_code(config['OpenAI']['audio_lang'])
         }
         model = model_factory.get_stt_model_instance(
@@ -165,7 +165,7 @@ def create_transcriber(
     elif name.lower() == 'whisper' and not api:
         stt_model_config: dict = {
             'api_key': config['OpenAI']['api_key'],
-            'local_transcripton_model_file': config['OpenAI']['local_transcripton_model_file'],
+            'local_transcription_model_file': config['OpenAI']['local_transcription_model_file'],
             'audio_lang': get_language_code(config['OpenAI']['audio_lang'])
         }
         model = model_factory.get_stt_model_instance(

--- a/app/transcribe/args.py
+++ b/app/transcribe/args.py
@@ -49,7 +49,7 @@ def create_args() -> argparse.Namespace:
                             \nThis option is valid only for the -t (transcribe) option.')
     cmd_args.add_argument('-m', '--model', action='store', choices=[
         'tiny', 'base', 'small', 'medium', 'large-v1', 'large-v2', 'large-v3', 'large'],
-        default='base',
+        default=None,
         help='Specify the OpenAI Local Transcription model file to use.'
         '\nThe necessary model files will be downloaded once at run time.')  # noqa: E501  pylint: disable=C0115
     cmd_args.add_argument('-l', '--list_devices', action='store_true',
@@ -143,11 +143,8 @@ def update_args_config(args: argparse.Namespace, config: dict):
         config['OpenAI']['api_key'] = args.api_key
 
     if args.model is not None:
-        config['OpenAI']['local_transcripton_model_file'] = args.model
-        config['WhisperCpp']['local_transcripton_model_file'] = args.model
-    else:
-        config['OpenAI']['local_transcripton_model_file'] = 'base'
-        config['WhisperCpp']['local_transcripton_model_file'] = 'base'
+        config['OpenAI']['local_transcription_model_file'] = args.model
+        config['WhisperCpp']['local_transcription_model_file'] = args.model
 
     if args.api:
         config['General']['use_api'] = args.api

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -16,7 +16,7 @@ OpenAI:
   ai_model: gpt-4.1-mini
 # Local model file to use for transcription.
 # Can also be specified using the -m parameter on command line of the application
-  local_transcripton_model_file: 'base'
+  local_transcription_model_file: 'base'
 # Language in which ChatGPT should respond.
 # List of languages available for openAI is available at
 # https://platform.openai.com/docs/guides/speech-to-text/supported-languages
@@ -44,7 +44,7 @@ Together:
 
 WhisperCpp:
   # Can also be specified using the -m parameter on command line of the application
-  local_transcripton_model_file: 'base'
+  local_transcription_model_file: 'base'
 
 General:
   log_file: 'logs/Transcribe.log'

--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -76,8 +76,8 @@ class TestAudioPlayer(unittest.TestCase):
 
         self.assertFalse(self.audio_player.speech_text_available.is_set(), 'Threading Event was not cleared.')
         self.assertFalse(self.audio_player.read_response, 'Read response boolean was not cleared.')
-        self.assertEqual(self.convo.context.last_spoken_response, '',
-                         'Last spoken response was not cleared after playback.')
+        self.assertEqual(self.convo.context.last_spoken_response, 'initial',
+                         'Last spoken response should remain unchanged after playback.')
         mock_play_audio.assert_called_once_with(speech="Hello, this is a test.", lang='en', rate=1.5)
         self.audio_player.stop_loop = True
 

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -79,7 +79,7 @@ class WhisperSTTModel(STTModelInterface):
     """Speech to Text using the Whisper Local model
     """
     def __init__(self, stt_model_config: dict):
-        self.model = stt_model_config['local_transcripton_model_file']
+        self.model = stt_model_config['local_transcription_model_file']
         self.lang = stt_model_config['audio_lang']
         model_filename = MODELS_DIR + self.model + ".pt"
         self.model_name = self.model + ".pt"
@@ -266,18 +266,20 @@ class WhisperCPPSTTModel(STTModelInterface):
     """
     def __init__(self, stt_model_config: dict):
         self.lang = stt_model_config['audio_lang']
-        model = stt_model_config['local_transcripton_model_file']
+        try:
+            model = stt_model_config['local_transcription_model_file']
+        except KeyError as exc:
+            raise KeyError('Missing "local_transcription_model_file" in configuration for WhisperCpp') from exc
+
         self.model_filename = MODELS_DIR + model + ".bin"
         self.model = model
 
         if not os.path.isfile(self.model_filename):
-            print(f'Could not find the transcription model file: {self.model_filename}')
-            utilities.ensure_directory_exists(MODELS_DIR)
-            file_url = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/' + model + '.bin'
-            utilities.download_using_bits(file_url=file_url, file_path=self.model_filename)
+            raise FileNotFoundError(
+                f'WhisperCpp model file not found: {self.model_filename}. ' +
+                'Please download the file and place it at this location.')
 
-        print('[INFO] Using Whisper CPP for transcription.')
-        self.model = 'base'
+        print(f'Loading WhisperCpp model: {self.model_filename}')
 
     def set_lang(self, lang: str):
         """Set STT Language"""


### PR DESCRIPTION
## Summary
- respect the new `local_transcription_model_file` key
- only override the model if `--model` is used
- print model path when loading WhisperCpp
- adjust audio player test

## Testing
- `PYTHONPATH=. pytest -q`