### PR TITLE
Add skeleton web interface and setup docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build image for Transcribe web version
+FROM python:3.11-slim AS backend
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . ./
+CMD ["uvicorn", "web.server:app", "--host", "0.0.0.0", "--port", "8000"]
+
+FROM node:20 AS frontend
+WORKDIR /app/client
+COPY web/client/package.json ./
+RUN npm install
+COPY web/client ./
+RUN npm run build
+
+FROM backend AS final
+COPY --from=frontend /app/client/dist ./web/client/dist
+EXPOSE 8000
+CMD ["uvicorn", "web.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Connect on LinkedIn to discuss further.
 ## Developer Guide ##
 [Developer Guide](./docs/DeveloperGuide.md)
 
+## Web Version ##
+See [WebSetup](./docs/WebSetup.md) for running Transcribe in a browser using FastAPI and React. Docker instructions are also provided.
+
+## Mobile Strategy ##
+An outline for Android and cross-platform options is available in [MobilePlan](./docs/MobilePlan.md).
+
 
 ## Software Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  transcribe:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+    command: uvicorn web.server:app --host 0.0.0.0 --port 8000

--- a/docs/MobilePlan.md
+++ b/docs/MobilePlan.md
@@ -1,0 +1,14 @@
+# Mobile Strategy
+
+This project does not yet provide a full mobile implementation. The recommended approach is to reuse the FastAPI backend and build a React Native client.
+
+## Approach 1: React Native
+- Share much of the web client code.
+- Use the backend API for transcription, TTS, and settings.
+- Bundle minimal native modules for microphone access.
+
+## Approach 2: Flutter
+- Build a Flutter application using platform channels for audio streaming.
+- Communicate with the FastAPI backend for model inference.
+
+Model files are heavy and typically remain on the server. Mobile apps stream audio to the server and receive transcription and responses.

--- a/docs/WebSetup.md
+++ b/docs/WebSetup.md
@@ -1,0 +1,36 @@
+# Web Version Setup
+
+This document describes how to run the Transcribe web application locally.
+
+## Prerequisites
+- Python 3.11+
+- Node.js 20+
+- npm
+- ffmpeg installed and available in your PATH
+
+## Setup Steps
+1. Install Python dependencies:
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+2. Install JavaScript dependencies:
+   ```bash
+   cd web/client
+   npm install
+   ```
+3. Start the FastAPI server and React dev server:
+   ```bash
+   # From repository root
+   uvicorn web.server:app --reload
+   # In another terminal
+   cd web/client && npm run start
+   ```
+
+The React app will proxy API requests to the FastAPI backend running on port 8000.
+
+## Docker
+You can also build and run using Docker:
+```bash
+docker compose up --build
+```
+This builds the backend and frontend images and serves the app on `http://localhost:8000`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ appdirs
 pillow==11.1.0
 wordcloud==1.9.4
 ffmpeg-python
+fastapi
+uvicorn
+websockets

--- a/scripts/setup_web.sh
+++ b/scripts/setup_web.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Setup script for web development
+python -m pip install -r requirements.txt
+cd web/client && npm install

--- a/tests_web/test_web.py
+++ b/tests_web/test_web.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from web.server import app
+
+client = TestClient(app)
+
+def test_read_write_settings():
+    response = client.post("/api/settings/test", params={"value": "123"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["value"] == "123"
+
+    response = client.get("/api/settings/test")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["value"] == "123"

--- a/web/client/README.md
+++ b/web/client/README.md
@@ -1,0 +1,5 @@
+# Transcribe Web Client
+
+This directory contains a React-based user interface for the Transcribe web application.
+
+Use `npm install` to install dependencies and `npm run start` to launch the development server.

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "transcribe-web-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@testing-library/react": "^14.0.0",
+    "jest": "^29.0.0"
+  }
+}

--- a/web/server.py
+++ b/web/server.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI, WebSocket, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+DATABASE_URL = "sqlite:///./web_settings.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Simple settings table using SQLAlchemy
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+class Setting(Base):
+    __tablename__ = "settings"
+    id = Column(Integer, primary_key=True, index=True)
+    key = Column(String, unique=True, index=True)
+    value = Column(String)
+
+Base.metadata.create_all(bind=engine)
+
+# Dependency to get DB session
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.get("/api/settings/{key}")
+async def read_setting(key: str, db=Depends(get_db)):
+    setting = db.query(Setting).filter(Setting.key == key).first()
+    if not setting:
+        raise HTTPException(status_code=404, detail="Setting not found")
+    return {"key": setting.key, "value": setting.value}
+
+@app.post("/api/settings/{key}")
+async def write_setting(key: str, value: str, db=Depends(get_db)):
+    setting = db.query(Setting).filter(Setting.key == key).first()
+    if setting:
+        setting.value = value
+    else:
+        setting = Setting(key=key, value=value)
+        db.add(setting)
+    db.commit()
+    return {"key": setting.key, "value": setting.value}
+
+# Placeholder endpoint for transcription
+@app.post("/api/transcribe")
+async def transcribe_audio():
+    """Stub endpoint for audio transcription."""
+    return {"text": "Transcription result"}
+
+# WebSocket echo server for streaming
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(f"Echo: {data}")
+    except Exception:
+        await websocket.close()


### PR DESCRIPTION
## Summary
- introduce FastAPI server and React client skeleton
- add Docker and compose setup
- document web and mobile instructions
- provide setup script and simple FastAPI test

## Testing
- `python -m pytest tests_web/test_web.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*