### PR TITLE
Add web-based app using FastAPI and React

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Connect on LinkedIn to discuss further.
 [Developer Guide](./docs/DeveloperGuide.md)
 
 ## Web Version ##
-See [WebSetup](./docs/WebSetup.md) for running Transcribe in a browser using FastAPI and React. Docker instructions are also provided.
+See [WebSetup](./docs/WebSetup.md) for running Transcribe in a browser using FastAPI and React. Docker instructions are also provided. Architectural details are covered in [WebArchitecture](./docs/WebArchitecture.md).
 
 ## Mobile Strategy ##
 An outline for Android and cross-platform options is available in [MobilePlan](./docs/MobilePlan.md).

--- a/docs/WebArchitecture.md
+++ b/docs/WebArchitecture.md
@@ -1,0 +1,53 @@
+# Web Architecture
+
+This document describes the web implementation of Transcribe. The web version reuses the
+existing Python backend and exposes a modern React interface.
+
+## Backend
+
+- **Framework**: FastAPI
+- **Endpoints**:
+  - `POST /api/transcribe` – speech‑to‑text using the `whisper` library.
+  - `POST /api/tts` – text‑to‑speech using `gtts` and returned as an MP3 stream.
+  - `POST /api/chat` – chat completion via the OpenAI client.
+  - `GET /api/models` – list available STT models.
+  - `GET/POST /api/settings/{key}` – persist settings in a SQLite DB.
+  - `WS /ws` – simple WebSocket interface for streaming.
+
+Heavy AI models remain on the server so the browser only streams audio and receives
+results. This keeps the client lightweight and works on mobile devices.
+
+## Frontend
+
+- **Framework**: React with Vite (see `package.json`).
+- Uses the MediaRecorder API for microphone capture.
+- Displays transcription results and chat history and offers basic playback
+  using the HTML5 `Audio` element.
+- Settings such as selected STT model are saved through the backend API and loaded on start.
+- Responsive CSS ensures usability on phones and desktops.
+
+## Deployment
+
+A multi‑stage `Dockerfile` builds both backend and frontend. For local development:
+
+```bash
+python -m pip install -r requirements.txt
+cd web/client && npm install
+uvicorn web.server:app --reload
+# in another terminal
+cd web/client && npm run start
+```
+
+For container deployment:
+
+```bash
+docker compose up --build
+```
+
+This serves the application on port `8000` with the static React build.
+
+## Mobile
+
+A minimal Android app can be built with React Native reusing most of the web
+code. The mobile client streams audio to the same FastAPI backend for inference
+and receives transcription, chat responses and MP3 playback URLs.

--- a/docs/WebSetup.md
+++ b/docs/WebSetup.md
@@ -28,6 +28,11 @@ This document describes how to run the Transcribe web application locally.
 
 The React app will proxy API requests to the FastAPI backend running on port 8000.
 
+Run automated tests with:
+```bash
+pytest tests_web
+```
+
 ## Docker
 You can also build and run using Docker:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ websockets
 requests
 httpx
 dataclasses-json
+sqlalchemy
+appdirs

--- a/tests_web/test_web.py
+++ b/tests_web/test_web.py
@@ -9,6 +9,55 @@ def test_read_write_settings():
     data = response.json()
     assert data["value"] == "123"
 
+
+def test_transcribe(monkeypatch):
+    class DummyModel:
+        def transcribe(self, path):
+            return {"text": "hi"}
+
+    monkeypatch.setattr("whisper.load_model", lambda name: DummyModel())
+    resp = client.post("/api/transcribe", files={"file": ("test.wav", b"data")})
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "hi"
+
+
+def test_tts(monkeypatch):
+    class DummyTTS:
+        def save(self, path):
+            with open(path, "wb") as f:
+                f.write(b"a")
+
+    monkeypatch.setattr("gtts.gTTS", lambda text, lang="en": DummyTTS())
+    resp = client.post("/api/tts", data={"text": "hello"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/mpeg"
+
+
+def test_chat(monkeypatch):
+    class DummyChoice:
+        message = type("obj", (), {"content": "world"})()
+
+    class DummyComp:
+        choices = [DummyChoice]
+
+    class DummyClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(model, messages):
+                    return DummyComp()
+
+    monkeypatch.setattr("openai.OpenAI", lambda: DummyClient())
+    resp = client.post("/api/chat", data={"message": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "world"
+
+
+def test_models():
+    resp = client.get("/api/models")
+    assert resp.status_code == 200
+    assert "models" in resp.json()
+
     response = client.get("/api/settings/test")
     assert response.status_code == 200
     data = response.json()

--- a/web/client/index.html
+++ b/web/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Transcribe Web</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/client/src/App.css
+++ b/web/client/src/App.css
@@ -1,42 +1,36 @@
-#root {
-  max-width: 1280px;
+.container {
+  max-width: 640px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: 1rem;
+  font-family: Arial, Helvetica, sans-serif;
 }
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+.transcript {
+  width: 100%;
+  margin-bottom: 1rem;
 }
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.chat-box {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  min-height: 150px;
 }
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.chat-box .assistant {
+  color: green;
+}
+.chat-input {
+  display: flex;
+  margin-top: 0.5rem;
+}
+.chat-input input {
+  flex: 1;
+  padding: 0.25rem;
+}
+@media (max-width: 600px) {
+  .controls {
+    flex-direction: column;
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/web/client/src/App.jsx
+++ b/web/client/src/App.jsx
@@ -1,34 +1,105 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useState, useRef, useEffect } from 'react'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [recording, setRecording] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const [message, setMessage] = useState('')
+  const [chat, setChat] = useState([])
+  const [models, setModels] = useState([])
+  const [model, setModel] = useState('base')
+  const recorderRef = useRef(null)
+  const chunksRef = useRef([])
+
+  useEffect(() => {
+    fetch('/api/models')
+      .then(r => r.json())
+      .then(d => {
+        setModels(d.models)
+        if (d.models?.length) setModel(d.models[0])
+      })
+    fetch('/api/settings/model')
+      .then(r => r.json())
+      .then(d => setModel(d.value))
+      .catch(() => {})
+  }, [])
+
+  const startRecording = async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    const rec = new MediaRecorder(stream)
+    rec.ondataavailable = e => {
+      if (e.data.size > 0) chunksRef.current.push(e.data)
+    }
+    rec.onstop = async () => {
+      const blob = new Blob(chunksRef.current, { type: 'audio/webm' })
+      chunksRef.current = []
+      const fd = new FormData()
+      fd.append('file', blob, 'recording.webm')
+      fd.append('model', model)
+      const resp = await fetch('/api/transcribe', { method: 'POST', body: fd })
+      const data = await resp.json()
+      setTranscript(t => t + '\n' + data.text)
+    }
+    recorderRef.current = rec
+    rec.start()
+    setRecording(true)
+  }
+
+  const stopRecording = () => {
+    recorderRef.current.stop()
+    setRecording(false)
+  }
+
+  const playTTS = async text => {
+    const fd = new FormData()
+    fd.append('text', text)
+    const resp = await fetch('/api/tts', { method: 'POST', body: fd })
+    const blob = await resp.blob()
+    new Audio(URL.createObjectURL(blob)).play()
+  }
+
+  const sendChat = async () => {
+    const fd = new FormData()
+    fd.append('message', message)
+    const resp = await fetch('/api/chat', { method: 'POST', body: fd })
+    const data = await resp.json()
+    setChat(c => [...c, { role: 'user', text: message }, { role: 'assistant', text: data.text }])
+    setMessage('')
+    playTTS(data.text)
+  }
+
+  const changeModel = async val => {
+    setModel(val)
+    const resp = await fetch(`/api/settings/model?value=${val}`, { method: 'POST' })
+    if (!resp.ok) console.error('Failed to save setting')
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="container">
+      <h1>Transcribe Web</h1>
+      <div className="controls">
+        {recording ? (
+          <button onClick={stopRecording}>Stop</button>
+        ) : (
+          <button onClick={startRecording}>Record</button>
+        )}
+        <select value={model} onChange={e => changeModel(e.target.value)}>
+          {models.map(m => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
+      <textarea readOnly value={transcript} rows="6" className="transcript" />
+      <div className="chat-box">
+        {chat.map((c, i) => (
+          <div key={i} className={c.role}>{c.text}</div>
+        ))}
+        <div className="chat-input">
+          <input value={message} onChange={e => setMessage(e.target.value)} placeholder="Say something" />
+          <button onClick={sendChat}>Send</button>
+        </div>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- implement FastAPI endpoints for transcription, TTS, chat and settings
- build simple React UI using MediaRecorder for audio
- persist settings in SQLite
- add docs for architecture and update setup instructions
- extend automated tests for new API endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pytest tests_web/test_web.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
