### PR TITLE
Enable real-time read aloud

### DIFF
--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -62,6 +62,7 @@ def initiate_app_threads(global_vars: TranscriptionGlobals,
         sys.exit(1)
     global_vars.responder.enabled = bool(config['General']['continuous_response'])
     global_vars.set_continuous_read(bool(config['General'].get('continuous_read', False)))
+    global_vars.set_real_time_read(bool(config['General'].get('real_time_read', False)))
 
     respond_thread = threading.Thread(target=global_vars.responder.respond_to_transcriber,
                                       name='Respond',

--- a/app/transcribe/appui.py
+++ b/app/transcribe/appui.py
@@ -865,14 +865,19 @@ def update_response_ui(responder: gr.GPTResponder,
         write_in_textbox(textbox, response)
         textbox.configure(state="disabled")
         textbox.see("end")
-        if (global_vars_module.continuous_read and
-                responder.streaming_complete.is_set() and
-                response != global_vars_module.last_spoken_response):
-            global_vars_module.last_tts_response = response
-            global_vars_module.last_spoken_response = response
-            global_vars_module.set_read_response(True)
-            global_vars_module.audio_player_var.speech_text_available.set()
-            responder.streaming_complete.clear()
+        if global_vars_module.continuous_read:
+            if global_vars_module.real_time_read:
+                if not response.startswith(global_vars_module.last_tts_response):
+                    global_vars_module.last_spoken_response = ""
+                if response != global_vars_module.last_tts_response:
+                    global_vars_module.last_tts_response = response
+            elif (responder.streaming_complete.is_set() and
+                  response != global_vars_module.last_spoken_response):
+                global_vars_module.last_tts_response = response
+                global_vars_module.last_spoken_response = response
+                global_vars_module.set_read_response(True)
+                global_vars_module.audio_player_var.speech_text_available.set()
+                responder.streaming_complete.clear()
 
     update_interval = int(update_interval_slider.get())
     responder.update_response_interval(update_interval)

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -107,12 +107,21 @@ class AudioPlayer:
                 # playback can be interrupted by new speech.
                 prev_sp_state = sp_rec.enabled
                 sp_rec.enabled = False
+                gv = self.conversation.context
                 try:
-                    self.play_audio(speech=final_speech, lang=lang_code, rate=rate)
+                    if gv.real_time_read:
+                        start = 0
+                        if final_speech.startswith(gv.last_spoken_response):
+                            start = len(gv.last_spoken_response)
+                        new_text = final_speech[start:]
+                        if new_text:
+                            gv.last_spoken_response += new_text
+                            self.play_audio(speech=new_text, lang=lang_code, rate=rate)
+                    else:
+                        self.play_audio(speech=final_speech, lang=lang_code, rate=rate)
                 finally:
                     time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
                     sp_rec.enabled = prev_sp_state
-                    gv = self.conversation.context
                     gv.last_playback_end = datetime.datetime.utcnow()
 
                     # Reset last_spoken_response so any queued text is cleared

--- a/app/transcribe/global_vars.py
+++ b/app/transcribe/global_vars.py
@@ -34,6 +34,8 @@ class TranscriptionGlobals(Singleton.Singleton):
     last_tts_response: str = ""
     # Last response actually spoken out loud
     last_spoken_response: str = ""
+    # Speak streaming text as it arrives
+    real_time_read: bool = False
     # Timestamp when the last TTS playback finished
     last_playback_end: datetime.datetime = None
     # LLM Response to an earlier conversation
@@ -84,6 +86,7 @@ class TranscriptionGlobals(Singleton.Singleton):
         self.continuous_read = False
         self.last_tts_response = ""
         self.last_spoken_response = ""
+        self.real_time_read = False
         self.last_playback_end = None
         self._initialized = True
 
@@ -120,6 +123,10 @@ class TranscriptionGlobals(Singleton.Singleton):
     def set_continuous_read(self, value: bool):
         """Toggle continuous read aloud of responses"""
         self.continuous_read = value
+
+    def set_real_time_read(self, value: bool):
+        """Toggle real-time read aloud of streaming responses"""
+        self.real_time_read = value
 
 
 # Instantiate a single copy of globals here itself

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -139,6 +139,10 @@ class GPTResponder:
                     self._update_conversation(persona=constants.PERSONA_ASSISTANT,
                                               response=collected_messages,
                                               update_previous=True)
+                    gv = self.conversation.context
+                    if gv.continuous_read and gv.real_time_read:
+                        gv.set_read_response(True)
+                        gv.audio_player_var.speech_text_available.set()
             self.streaming_complete.set()
             return collected_messages
 

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -87,6 +87,8 @@ General:
   llm_response_interval: 10
   # Playback speed for read-aloud responses
   tts_speech_rate: 1.3
+  # Begin speaking before the full response is displayed
+  real_time_read: No
 
 # This is equivalent to -c argument on command line
 # Command line argument takes precedence over value specified in parameters.yaml

--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -26,6 +26,7 @@ class TestAudioPlayer(unittest.TestCase):
         self.convo = MagicMock(spec=c.Conversation)
         self.convo.context = MagicMock()
         self.convo.context.last_spoken_response = "initial"
+        self.convo.context.real_time_read = False
         self.audio_player = AudioPlayer(convo=self.convo)
         self.config = {
             'OpenAI': {'response_lang': 'english'},


### PR DESCRIPTION
## Summary
- add `real_time_read` option to configuration and globals
- trigger audio playback while the response streams
- speak only newly generated text
- record progress of spoken text
- fix audio player tests for new flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e348a88d48321b0bf5cc25c2410b0