### PR TITLE
Improve real-time read aloud playback

### DIFF
--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -47,12 +47,17 @@ class AudioPlayer:
                     pass
         self.current_process = None
 
-    def play_audio(self, speech: str, lang: str, rate: float | None = None):
+    def play_audio(self, speech: str, lang: str, rate: float | None = None) -> bool:
         """Play text as audio.
+
         This is a blocking method and will return when audio playback is complete.
         For large audio text, this could take several minutes.
+
+        Returns:
+            bool: ``True`` if playback finished without interruption, ``False`` otherwise.
         """
         logger.info(f'{self.__class__.__name__} - Playing audio')  # pylint: disable=W1203
+        completed = True
         try:
             audio_obj = gtts.gTTS(speech, lang=lang)
             temp_audio_file = tempfile.mkstemp(dir=self.temp_dir, suffix='.mp3')
@@ -70,16 +75,25 @@ class AudioPlayer:
 
             while self.current_process.poll() is None:
                 if not self.conversation.context.audio_queue.empty():
+                    completed = False
+                    self.stop_current_playback()
+                    break
+                gv = self.conversation.context
+                if gv.real_time_read and self.speech_text_available.is_set():
+                    completed = False
                     self.stop_current_playback()
                     break
                 time.sleep(0.1)
         except Exception as play_ex:
             logger.error('Error when attempting to play audio.', exc_info=True)
             logger.info(play_ex)
+            completed = False
         finally:
             os.remove(temp_audio_file[1])
             with self.play_lock:
                 self.stop_current_playback()
+
+        return completed
 
     def play_audio_loop(self, config: dict):
         """Continuously play text as audio based on event signaling.
@@ -105,12 +119,14 @@ class AudioPlayer:
                 new_text = final_speech[start:]
 
                 if new_text:
+                    self.speech_text_available.clear()
                     sp_rec = gv.speaker_audio_recorder
                     prev_sp_state = sp_rec.enabled
                     sp_rec.enabled = False
                     try:
-                        gv.last_spoken_response += new_text
-                        self.play_audio(speech=new_text, lang=lang_code, rate=rate)
+                        played = self.play_audio(speech=new_text, lang=lang_code, rate=rate)
+                        if played:
+                            gv.last_spoken_response += new_text
                     finally:
                         time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
                         sp_rec.enabled = prev_sp_state
@@ -143,10 +159,15 @@ class AudioPlayer:
                             start = len(gv.last_spoken_response)
                         new_text = final_speech[start:]
                         if new_text:
-                            gv.last_spoken_response += new_text
-                            self.play_audio(speech=new_text, lang=lang_code, rate=rate)
+                            self.speech_text_available.clear()
+                            played = self.play_audio(speech=new_text, lang=lang_code, rate=rate)
+                            if played:
+                                gv.last_spoken_response += new_text
                     else:
-                        self.play_audio(speech=final_speech, lang=lang_code, rate=rate)
+                        self.speech_text_available.clear()
+                        played = self.play_audio(speech=final_speech, lang=lang_code, rate=rate)
+                        if played:
+                            gv.last_spoken_response = final_speech
                 finally:
                     time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
                     sp_rec.enabled = prev_sp_state

--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -48,7 +48,8 @@ class TestAudioPlayer(unittest.TestCase):
         mock_popen.side_effect = Exception('ffplay missing')
 
         with self.assertLogs(level='ERROR') as log:
-            self.audio_player.play_audio(speech, lang)
+            result = self.audio_player.play_audio(speech, lang)
+            self.assertFalse(result)
             self.assertIn('Error when attempting to play audio.', log.output[0])
 
     @patch.object(AudioPlayer, 'play_audio')
@@ -65,6 +66,7 @@ class TestAudioPlayer(unittest.TestCase):
         def side_effect(*args, **kwargs):
             self.audio_player.read_response = False
             self.audio_player.speech_text_available.clear()
+            return True
 
         mock_play_audio.side_effect = side_effect
         self.audio_player.speech_text_available.set()
@@ -77,8 +79,8 @@ class TestAudioPlayer(unittest.TestCase):
 
         self.assertFalse(self.audio_player.speech_text_available.is_set(), 'Threading Event was not cleared.')
         self.assertFalse(self.audio_player.read_response, 'Read response boolean was not cleared.')
-        self.assertEqual(self.convo.context.last_spoken_response, 'initial',
-                         'Last spoken response should remain unchanged after playback.')
+        self.assertEqual(self.convo.context.last_spoken_response, 'Hello, this is a test.',
+                         'Last spoken response should be updated after playback.')
         mock_play_audio.assert_called_once_with(speech="Hello, this is a test.", lang='en', rate=1.5)
         self.audio_player.stop_loop = True
 


### PR DESCRIPTION
## Summary
- adjust `play_audio` to return completion status
- interrupt playback when new text arrives for real-time read aloud
- update audio player tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419c57e0088321b66eb7a61a81cae9