### PR TITLE
Fix continuous response toggle

### DIFF
--- a/app/transcribe/appui.py
+++ b/app/transcribe/appui.py
@@ -543,15 +543,21 @@ class AppUI(ctk.CTk):
         """Respond to start / stop of seeking responses from openAI API"""
         logger.info(AppUI.freeze_unfreeze.__name__)
         try:
-            # Invert the state
-            self.global_vars.responder.enabled = not self.global_vars.responder.enabled
+            # Invert the state and persist in configuration
+            new_state = not self.global_vars.responder.enabled
+            self.global_vars.responder.enabled = new_state
+
+            config_obj = configuration.Config()
+            altered_config = {"General": {"continuous_response": bool(new_state)}}
+            config_obj.add_override_value(altered_config)
+
             self.capture_action(
-                f'{"Enabled " if self.global_vars.responder.enabled else "Disabled "} continuous LLM responses'
+                f'{"Enabled " if new_state else "Disabled "} continuous LLM responses'
             )
             self.continuous_response_button.configure(
                 text=(
                     "Suggest Responses Continuously"
-                    if not self.global_vars.responder.enabled
+                    if not new_state
                     else "Do Not Suggest Responses Continuously"
                 )
             )
@@ -677,7 +683,6 @@ class AppUI(ctk.CTk):
 
                 # Allow AudioPlayer to speak the entire response when triggered
                 self.global_vars.last_spoken_response = ""
-
 
             self.response_textbox.configure(state="normal")
             if response_string:

--- a/app/transcribe/tests/test_continuous_response.py
+++ b/app/transcribe/tests/test_continuous_response.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+from types import ModuleType
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+sys.modules["pyaudiowpatch"] = ModuleType("pyaudiowpatch")
+from tsutils import configuration
+
+configuration.Config.__init__ = lambda self, *a, **k: None
+from app.transcribe.appui import AppUI
+from tsutils.configuration import Config
+
+
+@unittest.skipIf("DISPLAY" not in os.environ, "requires display")
+class TestContinuousResponse(unittest.TestCase):
+    @patch.object(Config, "add_override_value")
+    def test_toggle_without_read(self, mock_add):
+        config = {
+            "General": {
+                "continuous_read": False,
+                "continuous_response": False,
+                "llm_response_interval": 10,
+                "chat_inference_provider": "openai",
+                "system_prompt": "test",
+                "initial_convo": {},
+            },
+            "OpenAI": {
+                "audio_lang": "english",
+                "response_lang": "english",
+                "api_key": "x",
+                "base_url": "y",
+                "ai_model": "z",
+            },
+        }
+        Config._current_data = config
+        ui = AppUI(config=config)
+        ui.global_vars.audio_player_var = MagicMock()
+        ui.global_vars.responder = MagicMock()
+        ui.global_vars.responder.enabled = False
+        ui.freeze_unfreeze()
+        self.assertTrue(ui.global_vars.responder.enabled)
+        mock_add.assert_called_with({"General": {"continuous_response": True}})
+        ui.freeze_unfreeze()
+        self.assertFalse(ui.global_vars.responder.enabled)
+        self.assertEqual(
+            mock_add.call_args_list[-1].args[0],
+            {"General": {"continuous_response": False}},
+        )
+
+    @patch.object(Config, "add_override_value")
+    def test_toggle_with_read_enabled(self, mock_add):
+        config = {
+            "General": {
+                "continuous_read": True,
+                "continuous_response": False,
+                "llm_response_interval": 10,
+                "chat_inference_provider": "openai",
+                "system_prompt": "test",
+                "initial_convo": {},
+            },
+            "OpenAI": {
+                "audio_lang": "english",
+                "response_lang": "english",
+                "api_key": "x",
+                "base_url": "y",
+                "ai_model": "z",
+            },
+        }
+        Config._current_data = config
+        ui = AppUI(config=config)
+        ui.global_vars.audio_player_var = MagicMock()
+        ui.global_vars.responder = MagicMock()
+        ui.global_vars.responder.enabled = False
+        ui.continuous_read_button.select()
+        ui.toggle_continuous_read()
+        ui.freeze_unfreeze()
+        self.assertTrue(ui.global_vars.responder.enabled)
+        mock_add.assert_any_call({"General": {"continuous_response": True}})
+        ui.freeze_unfreeze()
+        self.assertFalse(ui.global_vars.responder.enabled)
+        self.assertEqual(
+            mock_add.call_args_list[-1].args[0],
+            {"General": {"continuous_response": False}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure the `Suggest Responses Continuously` toggle updates config
- add regression tests for continuous response toggle behaviour

## Testing
- `bash scripts/setup_web.sh` *(fails: 403 Forbidden npm error)*
- `python -m py_compile app/transcribe/appui.py app/transcribe/tests/test_continuous_response.py`
- `black app/transcribe/appui.py app/transcribe/tests/test_continuous_response.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684200cf68088321a92ea99f773b4f12