### PR TITLE
Add streaming TTS playback

### DIFF
--- a/app/transcribe/appui.py
+++ b/app/transcribe/appui.py
@@ -36,8 +36,8 @@ pop_up = None
 
 
 class AppUI(ctk.CTk):
-    """Encapsulates all UI functionality for the app
-    """
+    """Encapsulates all UI functionality for the app"""
+
     global_vars: TranscriptionGlobals
     ui_filename: str = None
 
@@ -50,8 +50,7 @@ class AppUI(ctk.CTk):
         self.set_audio_device_menus(config=config)
 
     def start(self):
-        """Start showing the UI
-        """
+        """Start showing the UI"""
         self.mainloop()
 
     def update_last_row(self, speaker: str, input_text: str):
@@ -62,7 +61,7 @@ class AppUI(ctk.CTk):
         self.transcript_text.replace_multiple_newlines()
 
         # Add new line to end, since it was cleared by previous operation
-        self.transcript_text.add_text_to_bottom('\n')
+        self.transcript_text.add_text_to_bottom("\n")
 
         # Add a new row to the bottom with new text
         self.transcript_text.add_text_to_bottom(input_text)
@@ -70,30 +69,31 @@ class AppUI(ctk.CTk):
         self.transcript_text.scroll_to_bottom()
 
     def update_initial_transcripts(self):
-        """Set initial transcript in UI.
-        """
-        update_transcript_ui(self.global_vars.transcriber,
-                             self.transcript_text)
-        update_response_ui(self.global_vars.responder,
-                           self.response_textbox,
-                           self.update_interval_slider_label,
-                           self.update_interval_slider)
-        self.global_vars.convo.set_handlers(self.update_last_row,
-                                            self.transcript_text.add_text_to_bottom)
+        """Set initial transcript in UI."""
+        update_transcript_ui(self.global_vars.transcriber, self.transcript_text)
+        update_response_ui(
+            self.global_vars.responder,
+            self.response_textbox,
+            self.update_interval_slider_label,
+            self.update_interval_slider,
+        )
+        self.global_vars.convo.set_handlers(
+            self.update_last_row, self.transcript_text.add_text_to_bottom
+        )
 
     def clear_transcript(self):
-        """Clear transcript from all places where it exists.
-        """
+        """Clear transcript from all places where it exists."""
         self.transcript_text.clear_all_text()
-        self.global_vars.transcriber.clear_transcriber_context(self.global_vars.audio_queue)
+        self.global_vars.transcriber.clear_transcriber_context(
+            self.global_vars.audio_queue
+        )
 
     def create_ui_components(self, config: dict):
-        """Create all UI components
-        """
+        """Create all UI components"""
         ctk.set_appearance_mode("dark")
         ctk.set_default_color_theme("dark-blue")
         self.title("Transcribe")
-        self.configure(bg='#252422')
+        self.configure(bg="#252422")
         self.geometry("1200x800")
 
         # Frame for the main content
@@ -104,7 +104,9 @@ class AppUI(ctk.CTk):
 
         # Left side: SelectableTextComponent
         self.transcript_text: SelectableText = SelectableText(self.main_frame)
-        self.transcript_text.pack(side="left", fill="both", expand=True, padx=10, pady=10)
+        self.transcript_text.pack(
+            side="left", fill="both", expand=True, padx=10, pady=10
+        )
         self.transcript_text.set_callbacks(self.global_vars.convo.on_convo_select)
 
         # Right side: LLM Response
@@ -113,10 +115,13 @@ class AppUI(ctk.CTk):
 
         # LLM Response textbox
         self.min_response_textbox_width = 300
-        self.response_textbox = ctk.CTkTextbox(self.right_frame, self.min_response_textbox_width,
-                                               font=("Arial", UI_FONT_SIZE),
-                                               text_color='#639cdc',
-                                               wrap="word")
+        self.response_textbox = ctk.CTkTextbox(
+            self.right_frame,
+            self.min_response_textbox_width,
+            font=("Arial", UI_FONT_SIZE),
+            text_color="#639cdc",
+            wrap="word",
+        )
         self.response_textbox.pack(fill="both", expand=True)
         self.response_textbox.insert("0.0", prompts.INITIAL_RESPONSE)
 
@@ -124,131 +129,234 @@ class AppUI(ctk.CTk):
         self.bottom_frame = ctk.CTkFrame(self, border_color="white", border_width=2)
         self.bottom_frame.pack(side="bottom", fill="both", pady=10)
 
-        response_enabled = bool(config['General']['continuous_response'])
-        b_text = "Suggest Responses Continuously" if not response_enabled else "Do Not Suggest Responses Continuously"
+        response_enabled = bool(config["General"]["continuous_response"])
+        b_text = (
+            "Suggest Responses Continuously"
+            if not response_enabled
+            else "Do Not Suggest Responses Continuously"
+        )
         self.continuous_response_button = ctk.CTkButton(self.bottom_frame, text=b_text)
-        self.continuous_response_button.grid(row=0, column=4, padx=10, pady=3, sticky="nsew")
+        self.continuous_response_button.grid(
+            row=0, column=4, padx=10, pady=3, sticky="nsew"
+        )
         self.continuous_response_button.configure(command=self.freeze_unfreeze)
 
-        self.response_now_button = ctk.CTkButton(self.bottom_frame, text="Suggest Response Now")
+        self.response_now_button = ctk.CTkButton(
+            self.bottom_frame, text="Suggest Response Now"
+        )
         self.response_now_button.grid(row=1, column=4, padx=10, pady=3, sticky="nsew")
         self.response_now_button.configure(command=self.get_response_now)
 
-        self.read_response_now_button = ctk.CTkButton(self.bottom_frame, text="Suggest Response and Read")
-        self.read_response_now_button.grid(row=2, column=4, padx=10, pady=3, sticky="nsew")
-        self.read_response_now_button.configure(command=self.update_response_ui_and_read_now)
+        self.read_response_now_button = ctk.CTkButton(
+            self.bottom_frame, text="Suggest Response and Read"
+        )
+        self.read_response_now_button.grid(
+            row=2, column=4, padx=10, pady=3, sticky="nsew"
+        )
+        self.read_response_now_button.configure(
+            command=self.update_response_ui_and_read_now
+        )
 
         self.summarize_button = ctk.CTkButton(self.bottom_frame, text="Summarize")
         self.summarize_button.grid(row=3, column=4, padx=10, pady=3, sticky="nsew")
         self.summarize_button.configure(command=self.summarize)
 
         # word cloud button
-        self.word_cloud_button = ctk.CTkButton(self.bottom_frame, text="Display Word Cloud")
+        self.word_cloud_button = ctk.CTkButton(
+            self.bottom_frame, text="Display Word Cloud"
+        )
         self.word_cloud_button.grid(row=4, column=4, padx=10, pady=3, sticky="nsew")
         self.word_cloud_button.configure(command=self.word_cloud)
 
         # Continuous read aloud switch
-        read_enabled = bool(config['General'].get('continuous_read', False))
-        self.continuous_read_button = ctk.CTkSwitch(self.bottom_frame, text="Read Responses Continuously")
-        self.continuous_read_button.grid(row=5, column=4, padx=10, pady=3, sticky="nsew")
+        read_enabled = bool(config["General"].get("continuous_read", False))
+        self.continuous_read_button = ctk.CTkSwitch(
+            self.bottom_frame, text="Read Responses Continuously"
+        )
+        self.continuous_read_button.grid(
+            row=5, column=4, padx=10, pady=3, sticky="nsew"
+        )
         if read_enabled:
             self.continuous_read_button.select()
-        ToolTip(self.continuous_read_button,
-                msg='When enabled, all AI responses will be spoken aloud automatically.',
-                delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
-                padx=7, pady=7)
+        ToolTip(
+            self.continuous_read_button,
+            msg="When enabled, all AI responses will be spoken aloud automatically.",
+            delay=0.01,
+            follow=True,
+            parent_kwargs={"padx": 3, "pady": 3},
+            padx=7,
+            pady=7,
+        )
         self.continuous_read_button.configure(command=self.toggle_continuous_read)
 
         # Continuous LLM Response label, and slider
-        self.update_interval_slider_label = ctk.CTkLabel(self.bottom_frame, text="", font=("Arial", 12),
-                                                         text_color="#FFFCF2")
-        self.update_interval_slider_label.grid(row=0, column=0, columnspan=4, padx=10, pady=3, sticky="nsew")
-        self.update_interval_slider = ctk.CTkSlider(self.bottom_frame, from_=1, to=30, width=300,  # height=5,
-                                                    number_of_steps=29)
-        self.update_interval_slider.set(config['General']['llm_response_interval'])
-        self.update_interval_slider.grid(row=1, column=0, columnspan=4, padx=10, pady=3, sticky="nsew")
+        self.update_interval_slider_label = ctk.CTkLabel(
+            self.bottom_frame, text="", font=("Arial", 12), text_color="#FFFCF2"
+        )
+        self.update_interval_slider_label.grid(
+            row=0, column=0, columnspan=4, padx=10, pady=3, sticky="nsew"
+        )
+        self.update_interval_slider = ctk.CTkSlider(
+            self.bottom_frame,
+            from_=1,
+            to=30,
+            width=300,  # height=5,
+            number_of_steps=29,
+        )
+        self.update_interval_slider.set(config["General"]["llm_response_interval"])
+        self.update_interval_slider.grid(
+            row=1, column=0, columnspan=4, padx=10, pady=3, sticky="nsew"
+        )
         self.update_interval_slider.configure(command=self.update_interval_slider_value)
 
-        label_text = f'LLM Response interval: {int(self.update_interval_slider.get())} seconds'
+        label_text = (
+            f"LLM Response interval: {int(self.update_interval_slider.get())} seconds"
+        )
         self.update_interval_slider_label.configure(text=label_text)
 
         # Speech to text language selection label, dropdown
-        audio_lang_label = ctk.CTkLabel(self.bottom_frame, text="Audio Lang: ",
-                                        font=("Arial", 12),
-                                        text_color="#FFFCF2")
-        audio_lang_label.grid(row=2, column=0, padx=10, pady=3, sticky='nw')
+        audio_lang_label = ctk.CTkLabel(
+            self.bottom_frame,
+            text="Audio Lang: ",
+            font=("Arial", 12),
+            text_color="#FFFCF2",
+        )
+        audio_lang_label.grid(row=2, column=0, padx=10, pady=3, sticky="nw")
 
-        audio_lang = config['OpenAI']['audio_lang']
-        self.audio_lang_combobox = ctk.CTkOptionMenu(self.bottom_frame, width=15, values=list(LANGUAGES_DICT.values()))
+        audio_lang = config["OpenAI"]["audio_lang"]
+        self.audio_lang_combobox = ctk.CTkOptionMenu(
+            self.bottom_frame, width=15, values=list(LANGUAGES_DICT.values())
+        )
         self.audio_lang_combobox.set(audio_lang)
-        self.audio_lang_combobox.grid(row=2, column=1, ipadx=60, padx=10, pady=3, sticky="ne")
+        self.audio_lang_combobox.grid(
+            row=2, column=1, ipadx=60, padx=10, pady=3, sticky="ne"
+        )
         self.audio_lang_combobox.configure(command=self.set_audio_language)
 
         # LLM Response language selection label, dropdown
-        response_lang_label = ctk.CTkLabel(self.bottom_frame,
-                                           text="Response Lang: ",
-                                           font=("Arial", 12), text_color="#FFFCF2")
+        response_lang_label = ctk.CTkLabel(
+            self.bottom_frame,
+            text="Response Lang: ",
+            font=("Arial", 12),
+            text_color="#FFFCF2",
+        )
         response_lang_label.grid(row=2, column=2, padx=10, pady=3, sticky="nw")
 
-        response_lang = config['OpenAI']['response_lang']
-        self.response_lang_combobox = ctk.CTkOptionMenu(self.bottom_frame, width=15,
-                                                        values=list(LANGUAGES_DICT.values()))
+        response_lang = config["OpenAI"]["response_lang"]
+        self.response_lang_combobox = ctk.CTkOptionMenu(
+            self.bottom_frame, width=15, values=list(LANGUAGES_DICT.values())
+        )
         self.response_lang_combobox.set(response_lang)
-        self.response_lang_combobox.grid(row=2, column=3, ipadx=60, padx=10, pady=3, sticky="ne")
+        self.response_lang_combobox.grid(
+            row=2, column=3, ipadx=60, padx=10, pady=3, sticky="ne"
+        )
         self.response_lang_combobox.configure(command=self.set_response_language)
 
-        self.github_link = ctk.CTkLabel(self.bottom_frame, text="Star the Github Repo",
-                                        text_color="#639cdc", cursor="hand2")
+        self.github_link = ctk.CTkLabel(
+            self.bottom_frame,
+            text="Star the Github Repo",
+            text_color="#639cdc",
+            cursor="hand2",
+        )
         self.github_link.grid(row=3, column=0, padx=10, pady=3, sticky="wn")
-        self.github_link.bind('<Button-1>', lambda e:
-                              self.open_link('https://github.com/vivekuppal/transcribe?referer=desktop'))
+        self.github_link.bind(
+            "<Button-1>",
+            lambda e: self.open_link(
+                "https://github.com/vivekuppal/transcribe?referer=desktop"
+            ),
+        )
 
-        self.issue_link = ctk.CTkLabel(self.bottom_frame, text="Report an issue", text_color="#639cdc", cursor="hand2")
+        self.issue_link = ctk.CTkLabel(
+            self.bottom_frame,
+            text="Report an issue",
+            text_color="#639cdc",
+            cursor="hand2",
+        )
         self.issue_link.grid(row=3, column=1, padx=10, pady=3, sticky="wn")
-        self.issue_link.bind('<Button-1>', lambda e: self.open_link(
-            'https://github.com/vivekuppal/transcribe/issues/new?referer=desktop'))
+        self.issue_link.bind(
+            "<Button-1>",
+            lambda e: self.open_link(
+                "https://github.com/vivekuppal/transcribe/issues/new?referer=desktop"
+            ),
+        )
 
         # Create right click menu for transcript textbox.
-        self.transcript_text.add_right_click_menu(label="Generate response for selected text",
-                                                  command=self.get_response_selected_now)
-        self.transcript_text.add_right_click_menu(label="Save Transcript to File", command=self.save_file)
-        self.transcript_text.add_right_click_menu(label="Clear Audio Transcript", command=self.clear_transcript)
-        self.transcript_text.add_right_click_menu(label="Copy Transcript to Clipboard", command=self.copy_to_clipboard)
-        self.transcript_text.add_right_click_menu(label="Edit line", command=self.edit_current_line)
+        self.transcript_text.add_right_click_menu(
+            label="Generate response for selected text",
+            command=self.get_response_selected_now,
+        )
+        self.transcript_text.add_right_click_menu(
+            label="Save Transcript to File", command=self.save_file
+        )
+        self.transcript_text.add_right_click_menu(
+            label="Clear Audio Transcript", command=self.clear_transcript
+        )
+        self.transcript_text.add_right_click_menu(
+            label="Copy Transcript to Clipboard", command=self.copy_to_clipboard
+        )
+        self.transcript_text.add_right_click_menu(
+            label="Edit line", command=self.edit_current_line
+        )
         self.transcript_text.add_right_menu_separator()
         self.transcript_text.add_right_click_menu(label="Quit", command=self.quit)
 
-        chat_inference_provider = config['General']['chat_inference_provider']
-        if chat_inference_provider == 'openai':
-            api_key = config['OpenAI']['api_key']
-            base_url = config['OpenAI']['base_url']
-            model = config['OpenAI']['ai_model']
-        elif chat_inference_provider == 'together':
-            api_key = config['Together']['api_key']
-            base_url = config['Together']['base_url']
-            model = config['Together']['ai_model']
+        chat_inference_provider = config["General"]["chat_inference_provider"]
+        if chat_inference_provider == "openai":
+            api_key = config["OpenAI"]["api_key"]
+            base_url = config["OpenAI"]["base_url"]
+            model = config["OpenAI"]["ai_model"]
+        elif chat_inference_provider == "together":
+            api_key = config["Together"]["api_key"]
+            base_url = config["Together"]["base_url"]
+            model = config["Together"]["ai_model"]
 
-        if not utilities.is_api_key_valid(api_key=api_key, base_url=base_url, model=model):
+        if not utilities.is_api_key_valid(
+            api_key=api_key, base_url=base_url, model=model
+        ):
             # Disable buttons that interact with backend services
-            self.continuous_response_button.configure(state='disabled')
-            self.response_now_button.configure(state='disabled')
-            self.read_response_now_button.configure(state='disabled')
-            self.summarize_button.configure(state='disabled')
+            self.continuous_response_button.configure(state="disabled")
+            self.response_now_button.configure(state="disabled")
+            self.read_response_now_button.configure(state="disabled")
+            self.summarize_button.configure(state="disabled")
 
-            tt_msg = 'Add API Key in override.yaml to enable button'
+            tt_msg = "Add API Key in override.yaml to enable button"
             # Add tooltips for disabled buttons
-            ToolTip(self.continuous_response_button, msg=tt_msg,
-                    delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
-                    padx=7, pady=7)
-            ToolTip(self.response_now_button, msg=tt_msg,
-                    delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
-                    padx=7, pady=7)
-            ToolTip(self.read_response_now_button, msg=tt_msg,
-                    delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
-                    padx=7, pady=7)
-            ToolTip(self.summarize_button, msg=tt_msg,
-                    delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
-                    padx=7, pady=7)
+            ToolTip(
+                self.continuous_response_button,
+                msg=tt_msg,
+                delay=0.01,
+                follow=True,
+                parent_kwargs={"padx": 3, "pady": 3},
+                padx=7,
+                pady=7,
+            )
+            ToolTip(
+                self.response_now_button,
+                msg=tt_msg,
+                delay=0.01,
+                follow=True,
+                parent_kwargs={"padx": 3, "pady": 3},
+                padx=7,
+                pady=7,
+            )
+            ToolTip(
+                self.read_response_now_button,
+                msg=tt_msg,
+                delay=0.01,
+                follow=True,
+                parent_kwargs={"padx": 3, "pady": 3},
+                padx=7,
+                pady=7,
+            )
+            ToolTip(
+                self.summarize_button,
+                msg=tt_msg,
+                delay=0.01,
+                follow=True,
+                parent_kwargs={"padx": 3, "pady": 3},
+                padx=7,
+                pady=7,
+            )
 
         # self.grid_rowconfigure(0, weight=100)
         # self.grid_rowconfigure(1, weight=1)
@@ -257,35 +365,41 @@ class AppUI(ctk.CTk):
         # self.grid_columnconfigure(0, weight=1)
         # self.grid_columnconfigure(1, weight=1)
 
-
     def edit_current_line(self):
-        """Edit the selected line of text required
-        """
+        """Edit the selected line of text required"""
         try:
             ctk.set_appearance_mode("dark")
             ctk.set_default_color_theme("dark-blue")
 
             current_line = self.transcript_text.text_widget.index("insert linestart")
-            current_line_text = self.transcript_text.text_widget.get(current_line, f"{current_line} lineend")
+            current_line_text = self.transcript_text.text_widget.get(
+                current_line, f"{current_line} lineend"
+            )
 
             edit_window = tk.Toplevel(self)
             edit_window.title("Edit Line")
-            edit_window.configure(background='#252422')
+            edit_window.configure(background="#252422")
 
-            edit_text = tk.Text(edit_window, wrap="word", height=10, width=50,
-                                bg='#252422', font=("Arial", 20),
-                                foreground='#639cdc')
-            edit_text.pack(expand=True, fill='both')
+            edit_text = tk.Text(
+                edit_window,
+                wrap="word",
+                height=10,
+                width=50,
+                bg="#252422",
+                font=("Arial", 20),
+                foreground="#639cdc",
+            )
+            edit_text.pack(expand=True, fill="both")
             # Separate Person, text in this line
-            end_speaker = current_line_text.find(':')
+            end_speaker = current_line_text.find(":")
             if end_speaker == -1:
                 # Could not determine speaker in text
                 return
             speaker: str = current_line_text[:end_speaker].strip()
-            speaker_text: str = current_line_text[end_speaker+1:].strip()
-            if speaker_text[0] == '[':
+            speaker_text: str = current_line_text[end_speaker + 1 :].strip()
+            if speaker_text[0] == "[":
                 speaker_text = speaker_text[1:]
-            if speaker_text[-1] == ']':
+            if speaker_text[-1] == "]":
                 speaker_text = speaker_text[:-1]
             edit_text.insert(tk.END, speaker_text)
 
@@ -296,28 +410,38 @@ class AppUI(ctk.CTk):
                 # 3. Save in DBs
                 new_text = edit_text.get("1.0", tk.END).strip()
                 self.transcript_text.text_widget.configure(state="normal")
-                self.transcript_text.text_widget.delete(current_line, f"{current_line} lineend")
-                self.transcript_text.text_widget.insert(current_line, f'{speaker}: {new_text}')
+                self.transcript_text.text_widget.delete(
+                    current_line, f"{current_line} lineend"
+                )
+                self.transcript_text.text_widget.insert(
+                    current_line, f"{speaker}: {new_text}"
+                )
                 self.transcript_text.text_widget.configure(state="disabled")
                 # Separate persona, text
-                convo_id = self.global_vars.convo.get_convo_id(persona=speaker, input_text=speaker_text)
-                self.global_vars.convo.update_conversation_by_id(persona=speaker, convo_id=convo_id, text=new_text)
+                convo_id = self.global_vars.convo.get_convo_id(
+                    persona=speaker, input_text=speaker_text
+                )
+                self.global_vars.convo.update_conversation_by_id(
+                    persona=speaker, convo_id=convo_id, text=new_text
+                )
                 edit_window.destroy()
 
             def cancel_edit():
                 edit_window.destroy()
+
             save_button = ctk.CTkButton(edit_window, text="Save", command=save_edit)
             save_button.pack(side=ctk.LEFT, padx=10, pady=10)
 
-            cancel_button = ctk.CTkButton(edit_window, text="Cancel", command=cancel_edit)
+            cancel_button = ctk.CTkButton(
+                edit_window, text="Cancel", command=cancel_edit
+            )
             cancel_button.pack(side=ctk.RIGHT, padx=10, pady=10)
 
         except tk.TclError:
             pass  # No text in the line
 
     def create_menus(self):
-        """Create menus for the application
-        """
+        """Create menus for the application"""
         # Create the menu bar
         menubar = tk.Menu(self)
 
@@ -325,10 +449,14 @@ class AppUI(ctk.CTk):
         self.filemenu = tk.Menu(menubar, tearoff=False)
 
         # Add a "Save" menu item to the file menu
-        self.filemenu.add_command(label="Save Transcript to File", command=self.save_file)
+        self.filemenu.add_command(
+            label="Save Transcript to File", command=self.save_file
+        )
 
         # Add a "Pause" menu item to the file menu
-        self.filemenu.add_command(label="Pause Transcription", command=self.set_transcript_state)
+        self.filemenu.add_command(
+            label="Pause Transcription", command=self.set_transcript_state
+        )
 
         # Add a "Quit" menu item to the file menu
         self.filemenu.add_command(label="Quit", command=self.quit)
@@ -340,19 +468,24 @@ class AppUI(ctk.CTk):
         self.editmenu = tk.Menu(menubar, tearoff=False)
 
         # Add a "Clear Audio Transcript" menu item to the file menu
-        self.editmenu.add_command(label="Clear Audio Transcript", command=self.clear_transcript)
+        self.editmenu.add_command(
+            label="Clear Audio Transcript", command=self.clear_transcript
+        )
 
         # Add a "Copy To Clipboard" menu item to the file menu
-        self.editmenu.add_command(label="Copy Transcript to Clipboard",
-                                  command=self.copy_to_clipboard)
+        self.editmenu.add_command(
+            label="Copy Transcript to Clipboard", command=self.copy_to_clipboard
+        )
 
         # Add "Disable Speaker" menu item to file menu
-        self.editmenu.add_command(label="Disable Speaker",
-                                  command=self.enable_disable_speaker)
+        self.editmenu.add_command(
+            label="Disable Speaker", command=self.enable_disable_speaker
+        )
 
         # Add "Disable Microphone" menu item to file menu
-        self.editmenu.add_command(label="Disable Microphone",
-                                  command=self.enable_disable_microphone)
+        self.editmenu.add_command(
+            label="Disable Microphone", command=self.enable_disable_microphone
+        )
 
         # Add the edit menu to the menu bar
         menubar.add_cascade(label="Edit", menu=self.editmenu)
@@ -368,17 +501,17 @@ class AppUI(ctk.CTk):
         self.config(menu=menubar)
 
     def set_audio_device_menus(self, config):
-        if config['General']['disable_speaker']:
-            print('[INFO] Disabling Speaker')
+        if config["General"]["disable_speaker"]:
+            print("[INFO] Disabling Speaker")
             self.enable_disable_speaker()
 
-        if config['General']['disable_mic']:
-            print('[INFO] Disabling Microphone')
+        if config["General"]["disable_mic"]:
+            print("[INFO] Disabling Microphone")
             self.enable_disable_microphone()
 
     def copy_to_clipboard(self):
         """Copy transcription text data to clipboard.
-           Does not include responses from assistant.
+        Does not include responses from assistant.
         """
         logger.info(AppUI.copy_to_clipboard.__name__)
         self.capture_action("Copy transcript to clipboard")
@@ -389,32 +522,42 @@ class AppUI(ctk.CTk):
 
     def save_file(self):
         """Save transcription text data to file.
-           Does not include responses from assistant.
+        Does not include responses from assistant.
         """
         logger.info(AppUI.save_file.__name__)
-        filename = ctk.filedialog.asksaveasfilename(defaultextension='.txt',
-                                                    title='Save Transcription',
-                                                    filetypes=[("Text Files", "*.txt")])
-        self.capture_action(f'Save transcript to file:{filename}')
+        filename = ctk.filedialog.asksaveasfilename(
+            defaultextension=".txt",
+            title="Save Transcription",
+            filetypes=[("Text Files", "*.txt")],
+        )
+        self.capture_action(f"Save transcript to file:{filename}")
         if not filename:
             return
         try:
-            with open(file=filename, mode="w", encoding='utf-8') as file_handle:
+            with open(file=filename, mode="w", encoding="utf-8") as file_handle:
                 file_handle.write(self.global_vars.transcriber.get_transcript())
         except Exception as e:
             logger.error(f"Error saving file {filename}: {e}")
 
     def freeze_unfreeze(self):
-        """Respond to start / stop of seeking responses from openAI API
-        """
+        """Respond to start / stop of seeking responses from openAI API"""
         logger.info(AppUI.freeze_unfreeze.__name__)
         try:
             # Invert the state
             self.global_vars.responder.enabled = not self.global_vars.responder.enabled
-            self.capture_action(f'{"Enabled " if self.global_vars.responder.enabled else "Disabled "} continuous LLM responses')
-            self.continuous_response_button.configure(
-                text="Suggest Responses Continuously" if not self.global_vars.responder.enabled else "Do Not Suggest Responses Continuously"
+            self.capture_action(
+                f'{"Enabled " if self.global_vars.responder.enabled else "Disabled "} continuous LLM responses'
             )
+            self.continuous_response_button.configure(
+                text=(
+                    "Suggest Responses Continuously"
+                    if not self.global_vars.responder.enabled
+                    else "Do Not Suggest Responses Continuously"
+                )
+            )
+            if not self.global_vars.responder.enabled:
+                self.global_vars.audio_player_var.stop_current_playback()
+                self.global_vars.audio_player_var.clear_queue()
         except Exception as e:
             logger.error(f"Error toggling responder state: {e}")
 
@@ -425,51 +568,73 @@ class AppUI(ctk.CTk):
             new_state = bool(self.continuous_read_button.get())
             self.global_vars.set_continuous_read(new_state)
             config_obj = configuration.Config()
-            altered_config = {'General': {'continuous_read': bool(new_state)}}
+            altered_config = {"General": {"continuous_read": bool(new_state)}}
             config_obj.add_override_value(altered_config)
-            self.capture_action(f'{"Enabled " if new_state else "Disabled "} continuous read aloud')
+            self.capture_action(
+                f'{"Enabled " if new_state else "Disabled "} continuous read aloud'
+            )
         except Exception as e:
             logger.error(f"Error toggling continuous read state: {e}")
 
     def enable_disable_speaker(self):
-        """Toggles the state of speaker
-        """
+        """Toggles the state of speaker"""
         try:
-            self.global_vars.speaker_audio_recorder.enabled = not self.global_vars.speaker_audio_recorder.enabled
-            self.editmenu.entryconfigure(2, label="Disable Speaker" if self.global_vars.speaker_audio_recorder.enabled else "Enable Speaker")
-            self.capture_action(f'{"Enabled " if self.global_vars.speaker_audio_recorder.enabled else "Disabled "} speaker input')
+            self.global_vars.speaker_audio_recorder.enabled = (
+                not self.global_vars.speaker_audio_recorder.enabled
+            )
+            self.editmenu.entryconfigure(
+                2,
+                label=(
+                    "Disable Speaker"
+                    if self.global_vars.speaker_audio_recorder.enabled
+                    else "Enable Speaker"
+                ),
+            )
+            self.capture_action(
+                f'{"Enabled " if self.global_vars.speaker_audio_recorder.enabled else "Disabled "} speaker input'
+            )
         except Exception as e:
             logger.error(f"Error toggling speaker state: {e}")
 
     def enable_disable_microphone(self):
-        """Toggles the state of microphone
-        """
+        """Toggles the state of microphone"""
         try:
-            self.global_vars.user_audio_recorder.enabled = not self.global_vars.user_audio_recorder.enabled
-            self.editmenu.entryconfigure(3, label="Disable Microphone" if self.global_vars.user_audio_recorder.enabled else "Enable Microphone")
-            self.capture_action(f'{"Enabled " if self.global_vars.user_audio_recorder.enabled else "Disabled "} microphone input')
+            self.global_vars.user_audio_recorder.enabled = (
+                not self.global_vars.user_audio_recorder.enabled
+            )
+            self.editmenu.entryconfigure(
+                3,
+                label=(
+                    "Disable Microphone"
+                    if self.global_vars.user_audio_recorder.enabled
+                    else "Enable Microphone"
+                ),
+            )
+            self.capture_action(
+                f'{"Enabled " if self.global_vars.user_audio_recorder.enabled else "Disabled "} microphone input'
+            )
         except Exception as e:
             logger.error(f"Error toggling microphone state: {e}")
 
     def update_interval_slider_value(self, slider_value):
         """Update interval slider label to match the slider value
-           Update the config value
+        Update the config value
         """
         try:
             config_obj = configuration.Config()
             # Save config
-            altered_config = {'General': {'llm_response_interval': int(slider_value)}}
+            altered_config = {"General": {"llm_response_interval": int(slider_value)}}
             config_obj.add_override_value(altered_config)
 
-            label_text = f'LLM Response interval: {int(slider_value)} seconds'
+            label_text = f"LLM Response interval: {int(slider_value)} seconds"
             self.update_interval_slider_label.configure(text=label_text)
-            self.capture_action(f'Update LLM response interval to {int(slider_value)}')
+            self.capture_action(f"Update LLM response interval to {int(slider_value)}")
         except Exception as e:
             logger.error(f"Error updating slider value: {e}")
 
     def get_response_now(self):
         """Get response from LLM right away
-           Update the Response UI with the response
+        Update the Response UI with the response
         """
         if self.global_vars.update_response_now:
             # We are already in the middle of getting a response
@@ -479,25 +644,27 @@ class AppUI(ctk.CTk):
         # We need a separate thread to ensure UI is responsive as responses are
         # streamed back. Without the thread UI appears stuck as we stream the
         # responses back
-        self.capture_action('Get LLM response now')
-        response_ui_thread = threading.Thread(target=self.get_response_now_threaded,
-                                              name='GetResponseNow')
+        self.capture_action("Get LLM response now")
+        response_ui_thread = threading.Thread(
+            target=self.get_response_now_threaded, name="GetResponseNow"
+        )
         response_ui_thread.daemon = True
         response_ui_thread.start()
 
     def get_response_selected_now_threaded(self, text: str):
-        """Update response UI in a separate thread
-        """
-        self.update_response_ui_threaded(lambda: self.global_vars.responder.generate_response_for_selected_text(text))
+        """Update response UI in a separate thread"""
+        self.update_response_ui_threaded(
+            lambda: self.global_vars.responder.generate_response_for_selected_text(text)
+        )
 
     def get_response_now_threaded(self):
-        """Update response UI in a separate thread
-        """
-        self.update_response_ui_threaded(self.global_vars.responder.generate_response_from_transcript_no_check)
+        """Update response UI in a separate thread"""
+        self.update_response_ui_threaded(
+            self.global_vars.responder.generate_response_from_transcript_no_check
+        )
 
     def update_response_ui_threaded(self, response_generator):
-        """Helper method to update response UI in a separate thread
-        """
+        """Helper method to update response UI in a separate thread"""
         try:
             self.global_vars.update_response_now = True
             response_string = response_generator()
@@ -517,7 +684,7 @@ class AppUI(ctk.CTk):
 
     def get_response_selected_now(self):
         """Get response from LLM right away for selected_text
-           Update the Response UI with the response
+        Update the Response UI with the response
         """
         if self.global_vars.update_response_now:
             # We are already in the middle of getting a response
@@ -527,11 +694,13 @@ class AppUI(ctk.CTk):
         # We need a separate thread to ensure UI is responsive as responses are
         # streamed back. Without the thread UI appears stuck as we stream the
         # responses back
-        self.capture_action('Get LLM response selected now')
+        self.capture_action("Get LLM response selected now")
         selected_text = self.transcript_text.selection_get()
-        response_ui_thread = threading.Thread(target=self.get_response_selected_now_threaded,
-                                              args=(selected_text,),
-                                              name='GetResponseSelectedNow')
+        response_ui_thread = threading.Thread(
+            target=self.get_response_selected_now_threaded,
+            args=(selected_text,),
+            name="GetResponseSelectedNow",
+        )
         response_ui_thread.daemon = True
         response_ui_thread.start()
 
@@ -539,8 +708,8 @@ class AppUI(ctk.CTk):
         """Get summary from LLM in a separate thread"""
         global pop_up  # pylint: disable=W0603
         try:
-            print('Summarizing...')
-            popup_msg_no_close(title='Summary', msg='Creating a summary')
+            print("Summarizing...")
+            popup_msg_no_close(title="Summary", msg="Creating a summary")
             summary = self.global_vars.responder.summarize()
             # When API key is not specified, give a chance for the thread to initialize
 
@@ -550,17 +719,19 @@ class AppUI(ctk.CTk):
                 except Exception as e:
                     # Somehow we get the exception
                     # RuntimeError: main thread is not in main loop
-                    logger.info('Exception in summarize_threaded')
+                    logger.info("Exception in summarize_threaded")
                     logger.info(e)
 
                 pop_up = None
             if summary is None:
-                popup_msg_close_button(title='Summary',
-                                       msg='Failed to get summary. Please check you have a valid API key.')
+                popup_msg_close_button(
+                    title="Summary",
+                    msg="Failed to get summary. Please check you have a valid API key.",
+                )
                 return
 
             # Enhancement here would be to get a streaming summary
-            popup_msg_close_button(title='Summary', msg=summary)
+            popup_msg_close_button(title="Summary", msg=summary)
         except Exception as e:
             logger.error(f"Error in summarize_threaded: {e}")
 
@@ -574,16 +745,29 @@ class AppUI(ctk.CTk):
                 except Exception as e:
                     # Somehow we get the exception
                     # RuntimeError: main thread is not in main loop
-                    logger.info('Exception in word_cloud_threaded')
+                    logger.info("Exception in word_cloud_threaded")
                     logger.info(e)
 
                 pop_up = None
 
             try:
-                words = self.global_vars.convo.get_conversation(sources = [constants.PERSONA_YOU, constants.PERSONA_SPEAKER, constants.PERSONA_ASSISTANT], length = 0)
-                processed_text = re.sub(r'^(You|Speaker|assistant):\s*', '', words, flags=re.MULTILINE)
-                word_cloud = WordCloud(background_color='white', colormap='binary', width=500, height=500).generate(processed_text[80:])
-                popup_msg_close_button_word_cloud(title='Word Cloud', word_cloud = word_cloud)
+                words = self.global_vars.convo.get_conversation(
+                    sources=[
+                        constants.PERSONA_YOU,
+                        constants.PERSONA_SPEAKER,
+                        constants.PERSONA_ASSISTANT,
+                    ],
+                    length=0,
+                )
+                processed_text = re.sub(
+                    r"^(You|Speaker|assistant):\s*", "", words, flags=re.MULTILINE
+                )
+                word_cloud = WordCloud(
+                    background_color="white", colormap="binary", width=500, height=500
+                ).generate(processed_text[80:])
+                popup_msg_close_button_word_cloud(
+                    title="Word Cloud", word_cloud=word_cloud
+                )
 
             except Exception as e:
                 print(f"Error generating word cloud: {e}")
@@ -592,41 +776,45 @@ class AppUI(ctk.CTk):
         except Exception as e:
             logger.error(f"Error in word_cloud_threaded: {e}")
 
-
     def summarize(self):
-        """Get summary response from LLM
-        """
-        self.capture_action('Get summary from LLM')
-        summarize_ui_thread = threading.Thread(target=self.summarize_threaded,
-                                               name='Summarize')
+        """Get summary response from LLM"""
+        self.capture_action("Get summary from LLM")
+        summarize_ui_thread = threading.Thread(
+            target=self.summarize_threaded, name="Summarize"
+        )
         summarize_ui_thread.daemon = True
         summarize_ui_thread.start()
 
     def word_cloud(self):
         """Start the word cloud thread"""
-        cloud = self.capture_action('Generate word cloud')
-        word_cloud_ui_thread = threading.Thread(target=self.word_cloud_threaded, name = 'Word Cloud')
+        cloud = self.capture_action("Generate word cloud")
+        word_cloud_ui_thread = threading.Thread(
+            target=self.word_cloud_threaded, name="Word Cloud"
+        )
         word_cloud_ui_thread.daemon = True
         word_cloud_ui_thread.start()
-
 
     def update_response_ui_and_read_now(self):
         """Get response from LLM right away
         Update the Response UI with the response
         Read the response
         """
-        self.capture_action('Get LLM response now and read aloud')
+        self.capture_action("Get LLM response now and read aloud")
         self.global_vars.set_read_response(True)
         self.get_response_now()
 
     def set_transcript_state(self):
         """Enables, disables transcription.
-           Text of menu item File -> Pause Transcription toggles accordingly
+        Text of menu item File -> Pause Transcription toggles accordingly
         """
         logger.info(AppUI.set_transcript_state.__name__)
         try:
-            self.global_vars.transcriber.transcribe = not self.global_vars.transcriber.transcribe
-            self.capture_action(f'{"Enabled " if self.global_vars.transcriber.transcribe else "Disabled "} transcription.')
+            self.global_vars.transcriber.transcribe = (
+                not self.global_vars.transcriber.transcribe
+            )
+            self.capture_action(
+                f'{"Enabled " if self.global_vars.transcriber.transcribe else "Disabled "} transcription.'
+            )
             if self.global_vars.transcriber.transcribe:
                 self.filemenu.entryconfigure(1, label="Pause Transcription")
             else:
@@ -635,56 +823,54 @@ class AppUI(ctk.CTk):
             logger.error(f"Error setting transcript state: {e}")
 
     def open_link(self, url: str):
-        """Open the link in a web browser
-        """
-        self.capture_action(f'Navigate to {url}.')
+        """Open the link in a web browser"""
+        self.capture_action(f"Navigate to {url}.")
         try:
             webbrowser.open(url=url, new=2)
         except Exception as e:
             logger.error(f"Error opening URL {url}: {e}")
 
     def open_github(self):
-        """Link to git repo main page
-        """
-        self.capture_action('open_github.')
-        self.open_link('https://github.com/vivekuppal/transcribe?referer=desktop')
+        """Link to git repo main page"""
+        self.capture_action("open_github.")
+        self.open_link("https://github.com/vivekuppal/transcribe?referer=desktop")
 
     def open_support(self):
-        """Link to git repo issues page
-        """
-        self.capture_action('open_support.')
-        self.open_link('https://github.com/vivekuppal/transcribe/issues/new?referer=desktop')
+        """Link to git repo issues page"""
+        self.capture_action("open_support.")
+        self.open_link(
+            "https://github.com/vivekuppal/transcribe/issues/new?referer=desktop"
+        )
 
     def capture_action(self, action_text: str):
-        """Write to file
-        """
+        """Write to file"""
         try:
             if not self.ui_filename:
-                data_dir = utilities.get_data_path(app_name='Transcribe')
-                self.ui_filename = utilities.incrementing_filename(filename=f'{data_dir}/logs/ui', extension='txt')
-            with open(self.ui_filename, mode='a', encoding='utf-8') as ui_file:
-                ui_file.write(f'{datetime.datetime.now()}: {action_text}\n')
+                data_dir = utilities.get_data_path(app_name="Transcribe")
+                self.ui_filename = utilities.incrementing_filename(
+                    filename=f"{data_dir}/logs/ui", extension="txt"
+                )
+            with open(self.ui_filename, mode="a", encoding="utf-8") as ui_file:
+                ui_file.write(f"{datetime.datetime.now()}: {action_text}\n")
         except Exception as e:
             logger.error(f"Error capturing action {action_text}: {e}")
 
     def set_audio_language(self, lang: str):
-        """Alter audio language in memory and persist it in config file
-        """
+        """Alter audio language in memory and persist it in config file"""
         try:
             self.global_vars.transcriber.stt_model.set_lang(lang)
             config_obj = configuration.Config()
             # Save config
-            altered_config = {'OpenAI': {'audio_lang': lang}}
+            altered_config = {"OpenAI": {"audio_lang": lang}}
             config_obj.add_override_value(altered_config)
         except Exception as e:
             logger.error(f"Error setting audio language: {e}")
 
     def set_response_language(self, lang: str):
-        """Alter response language in memory and persist it in config file
-        """
+        """Alter response language in memory and persist it in config file"""
         try:
             config_obj = configuration.Config()
-            altered_config = {'OpenAI': {'response_lang': lang}}
+            altered_config = {"OpenAI": {"response_lang": lang}}
             # Save config
             config_obj.add_override_value(altered_config)
             config_data = config_obj.data
@@ -693,32 +879,32 @@ class AppUI(ctk.CTk):
             prompt = config_data["General"]["system_prompt"]
             response_lang = config_data["OpenAI"]["response_lang"]
             if response_lang is not None:
-                prompt += f'.  Respond exclusively in {response_lang}.'
+                prompt += f".  Respond exclusively in {response_lang}."
             convo = self.global_vars.convo
-            convo.update_conversation(persona=constants.PERSONA_SYSTEM,
-                                      text=prompt,
-                                      time_spoken=datetime.datetime.utcnow(),
-                                      update_previous=True)
+            convo.update_conversation(
+                persona=constants.PERSONA_SYSTEM,
+                text=prompt,
+                time_spoken=datetime.datetime.utcnow(),
+                update_previous=True,
+            )
         except Exception as e:
             logger.error(f"Error setting response language: {e}")
 
 
 def popup_msg_no_close_threaded(title, msg):
-    """Create a pop up with no close button.
-    """
+    """Create a pop up with no close button."""
     global pop_up  # pylint: disable=W0603
     try:
         popup = ctk.CTkToplevel(T_GLOBALS.main_window)
         popup.geometry("100x50")
         popup.title(title)
-        label = ctk.CTkLabel(popup, text=msg, font=("Arial", 12),
-                             text_color="#FFFCF2")
+        label = ctk.CTkLabel(popup, text=msg, font=("Arial", 12), text_color="#FFFCF2")
         label.pack(side="top", fill="x", pady=10)
         pop_up = popup
         popup.lift()
     except Exception as e:
         # Sometimes get the error - calling Tcl from different apartment
-        logger.info('Exception in popup_msg_no_close_threaded')
+        logger.info("Exception in popup_msg_no_close_threaded")
         logger.info(e)
         return
 
@@ -728,11 +914,11 @@ def popup_msg_no_close(title: str, msg: str):
     using the destroy method
     """
     kwargs = {}
-    kwargs['title'] = title
-    kwargs['msg'] = msg
-    pop_ui_thread = threading.Thread(target=popup_msg_no_close_threaded,
-                                     name='Pop up thread',
-                                     kwargs=kwargs)
+    kwargs["title"] = title
+    kwargs["msg"] = msg
+    pop_ui_thread = threading.Thread(
+        target=popup_msg_no_close_threaded, name="Pop up thread", kwargs=kwargs
+    )
     pop_ui_thread.daemon = True
     pop_ui_thread.start()
     # Give a chance for the thread to initialize
@@ -748,20 +934,29 @@ def popup_msg_close_button(title: str, msg: str):
     popup = ctk.CTkToplevel(T_GLOBALS.main_window)
     popup.geometry("380x710")
     popup.title(title)
-    txtbox = ctk.CTkTextbox(popup, width=350, height=600, font=("Arial", UI_FONT_SIZE),
-                            text_color='#FFFCF2', wrap="word")
+    txtbox = ctk.CTkTextbox(
+        popup,
+        width=350,
+        height=600,
+        font=("Arial", UI_FONT_SIZE),
+        text_color="#FFFCF2",
+        wrap="word",
+    )
     txtbox.grid(row=0, column=0, padx=10, pady=10, sticky="nsew")
     txtbox.insert("0.0", msg)
 
     def copy_summary_to_clipboard():
         pyperclip.copy(txtbox.cget("text"))
 
-    copy_button = ctk.CTkButton(popup, text="Copy to Clipboard", command=copy_summary_to_clipboard)
+    copy_button = ctk.CTkButton(
+        popup, text="Copy to Clipboard", command=copy_summary_to_clipboard
+    )
     copy_button.grid(row=1, column=0, padx=10, pady=5, sticky="nsew")
 
     close_button = ctk.CTkButton(popup, text="Close", command=popup.destroy)
     close_button.grid(row=2, column=0, padx=10, pady=5, sticky="nsew")
     popup.lift()
+
 
 def popup_msg_close_button_word_cloud(title: str, word_cloud):
     """Create a word cloud popup that caller is responsible for closing
@@ -770,7 +965,7 @@ def popup_msg_close_button_word_cloud(title: str, word_cloud):
     popup = ctk.CTkToplevel(T_GLOBALS.main_window)
     popup.geometry("380x400")
     popup.title(title)
-    
+
     # Render the WordCloud to an image
     try:
         buffer = BytesIO()
@@ -796,24 +991,24 @@ def popup_msg_close_button_word_cloud(title: str, word_cloud):
 
 def write_in_textbox(textbox: ctk.CTkTextbox, text: str):
     """Update the text of textbox with the given text
-        Args:
-          textbox: textbox to be updated
-          text: updated text
+    Args:
+      textbox: textbox to be updated
+      text: updated text
     """
     # Get current selection attributes, so they can be preserved after writing new text
-    a: tuple = textbox.tag_ranges('sel')
+    a: tuple = textbox.tag_ranges("sel")
     # (<string object: '5.22'>, <string object: '5.85'>)
     textbox.delete("0.0", "end")
     textbox.insert("0.0", text)
     if len(a):
-        textbox.tag_add('sel', a[0], a[1])
+        textbox.tag_add("sel", a[0], a[1])
 
 
 def update_transcript_ui(transcriber: AudioTranscriber, textbox: SelectableText):
     """Update the text of transcription textbox with the given text
-        Args:
-          transcriber: AudioTranscriber Object
-          textbox: SelectableText to be updated
+    Args:
+      transcriber: AudioTranscriber Object
+      textbox: SelectableText to be updated
     """
 
     global last_transcript_ui_update_time  # pylint: disable=W0603
@@ -823,7 +1018,10 @@ def update_transcript_ui(transcriber: AudioTranscriber, textbox: SelectableText)
         global_vars_module = TranscriptionGlobals()
 
     # None comparison is for initialization
-    if last_transcript_ui_update_time is None or last_transcript_ui_update_time < global_vars_module.convo.last_update:
+    if (
+        last_transcript_ui_update_time is None
+        or last_transcript_ui_update_time < global_vars_module.convo.last_update
+    ):
         transcript_strings = transcriber.get_transcript()
         if isinstance(transcript_strings, list):
             for line in transcript_strings:
@@ -835,14 +1033,16 @@ def update_transcript_ui(transcriber: AudioTranscriber, textbox: SelectableText)
         last_transcript_ui_update_time = datetime.datetime.utcnow()
 
 
-def update_response_ui(responder: gr.GPTResponder,
-                       textbox: ctk.CTkTextbox,
-                       update_interval_slider_label: ctk.CTkLabel,
-                       update_interval_slider: ctk.CTkSlider):
+def update_response_ui(
+    responder: gr.GPTResponder,
+    textbox: ctk.CTkTextbox,
+    update_interval_slider_label: ctk.CTkLabel,
+    update_interval_slider: ctk.CTkSlider,
+):
     """Update the text of response textbox with the given text
-        Args:
-          textbox: textbox to be updated
-          text: updated text
+    Args:
+      textbox: textbox to be updated
+      text: updated text
     """
     global global_vars_module  # pylint: disable=W0603
 
@@ -865,9 +1065,12 @@ def update_response_ui(responder: gr.GPTResponder,
         write_in_textbox(textbox, response)
         textbox.configure(state="disabled")
         textbox.see("end")
-        if (global_vars_module.continuous_read and
-                responder.streaming_complete.is_set() and
-                response != global_vars_module.last_spoken_response):
+        if (
+            global_vars_module.continuous_read
+            and responder.streaming_complete.is_set()
+            and response != global_vars_module.last_spoken_response
+            and not global_vars_module.responder.enabled
+        ):
             global_vars_module.last_tts_response = response
             global_vars_module.last_spoken_response = response
             global_vars_module.set_read_response(True)
@@ -876,8 +1079,15 @@ def update_response_ui(responder: gr.GPTResponder,
 
     update_interval = int(update_interval_slider.get())
     responder.update_response_interval(update_interval)
-    update_interval_slider_label.configure(text=f'LLM Response interval: '
-                                           f'{update_interval} seconds')
+    update_interval_slider_label.configure(
+        text=f"LLM Response interval: " f"{update_interval} seconds"
+    )
 
-    textbox.after(300, update_response_ui, responder, textbox,
-                  update_interval_slider_label, update_interval_slider)
+    textbox.after(
+        300,
+        update_response_ui,
+        responder,
+        textbox,
+        update_interval_slider_label,
+        update_interval_slider,
+    )

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -11,6 +11,7 @@ import subprocess
 import datetime
 import playsound
 import gtts
+import queue
 from conversation import Conversation
 import constants
 from tsutils import app_logging as al
@@ -20,8 +21,7 @@ logger = al.get_module_logger(al.AUDIO_PLAYER_LOGGER)
 
 
 class AudioPlayer:
-    """Play text to audio.
-    """
+    """Play text to audio."""
 
     def __init__(self, convo: Conversation):
         logger.info(self.__class__.__name__)
@@ -33,6 +33,20 @@ class AudioPlayer:
         self.current_process = None
         self.play_lock = threading.Lock()
         self.speech_rate = constants.DEFAULT_TTS_SPEECH_RATE
+        self.chunk_queue: queue.Queue[str] = queue.Queue()
+
+    def enqueue_chunk(self, chunk: str):
+        """Queue a chunk of text for immediate playback."""
+        if chunk:
+            self.chunk_queue.put(chunk)
+
+    def clear_queue(self):
+        """Clear any queued chunks waiting to be spoken."""
+        while not self.chunk_queue.empty():
+            try:
+                self.chunk_queue.get_nowait()
+            except queue.Empty:
+                break
 
     def stop_current_playback(self):
         """Stop any current audio playback"""
@@ -52,21 +66,24 @@ class AudioPlayer:
         This is a blocking method and will return when audio playback is complete.
         For large audio text, this could take several minutes.
         """
-        logger.info(f'{self.__class__.__name__} - Playing audio')  # pylint: disable=W1203
+        logger.info(
+            f"{self.__class__.__name__} - Playing audio"
+        )  # pylint: disable=W1203
         try:
             audio_obj = gtts.gTTS(speech, lang=lang)
-            temp_audio_file = tempfile.mkstemp(dir=self.temp_dir, suffix='.mp3')
+            temp_audio_file = tempfile.mkstemp(dir=self.temp_dir, suffix=".mp3")
             os.close(temp_audio_file[0])
 
             audio_obj.save(temp_audio_file[1])
             with self.play_lock:
                 self.stop_current_playback()
-                cmd = ['ffplay', '-nodisp', '-autoexit', '-loglevel', 'quiet']
+                cmd = ["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet"]
                 if rate and rate != 1.0:
-                    cmd += ['-af', f'atempo={rate}']
+                    cmd += ["-af", f"atempo={rate}"]
                 cmd.append(temp_audio_file[1])
                 self.current_process = subprocess.Popen(
-                    cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                )
 
             while self.current_process.poll() is None:
                 if not self.conversation.context.audio_queue.empty():
@@ -74,7 +91,7 @@ class AudioPlayer:
                     break
                 time.sleep(0.1)
         except Exception as play_ex:
-            logger.error('Error when attempting to play audio.', exc_info=True)
+            logger.error("Error when attempting to play audio.", exc_info=True)
             logger.info(play_ex)
         finally:
             os.remove(temp_audio_file[1])
@@ -82,20 +99,37 @@ class AudioPlayer:
                 self.stop_current_playback()
 
     def play_audio_loop(self, config: dict):
-        """Continuously play text as audio based on event signaling.
-        """
-        lang = 'english'
+        """Continuously play text as audio based on event signaling."""
+        lang = "english"
         lang_code = self._get_language_code(lang)
-        rate = config.get('General', {}).get('tts_speech_rate', self.speech_rate)
+        rate = config.get("General", {}).get("tts_speech_rate", self.speech_rate)
         self.speech_rate = rate
 
         while self.stop_loop is False:
+            if not self.chunk_queue.empty():
+                chunk = self.chunk_queue.get()
+                new_lang = config.get("OpenAI", {}).get("response_lang", lang)
+                if new_lang != lang:
+                    lang_code = self._get_language_code(new_lang)
+                    lang = new_lang
+
+                sp_rec = self.conversation.context.speaker_audio_recorder
+                prev_sp_state = sp_rec.enabled
+                sp_rec.enabled = False
+                try:
+                    self.play_audio(speech=chunk, lang=lang_code, rate=rate)
+                finally:
+                    time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
+                    sp_rec.enabled = prev_sp_state
+                    gv = self.conversation.context
+                    gv.last_playback_end = datetime.datetime.utcnow()
+
             if self.speech_text_available.is_set() and self.read_response:
                 self.speech_text_available.clear()
                 speech = self._get_speech_text()
                 final_speech = self._process_speech_text(speech)
 
-                new_lang = config.get('OpenAI', {}).get('response_lang', lang)
+                new_lang = config.get("OpenAI", {}).get("response_lang", lang)
                 if new_lang != lang:
                     lang_code = self._get_language_code(new_lang)
                     lang = new_lang
@@ -126,22 +160,21 @@ class AudioPlayer:
             time.sleep(0.1)
 
     def _get_language_code(self, lang: str) -> str:
-        """Get the language code from the configuration.
-        """
+        """Get the language code from the configuration."""
         try:
             return next(key for key, value in LANGUAGES_DICT.items() if value == lang)
         except StopIteration:
             # Return dafault lang if nothing else is found
-            return 'en'
+            return "en"
 
     def _get_speech_text(self) -> str:
-        """Get the speech text from the conversation.
-        """
-        return self.conversation.get_conversation(sources=[constants.PERSONA_ASSISTANT], length=1)
+        """Get the speech text from the conversation."""
+        return self.conversation.get_conversation(
+            sources=[constants.PERSONA_ASSISTANT], length=1
+        )
 
     def _process_speech_text(self, speech: str) -> str:
-        """Process the speech text to remove persona and formatting.
-        """
+        """Process the speech text to remove persona and formatting."""
         persona_length = len(constants.PERSONA_ASSISTANT) + 2
         final_speech = speech[persona_length:].strip()
         return final_speech[1:-1]  # Remove square brackets

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -2,15 +2,13 @@ import datetime
 import time
 from enum import Enum
 import threading
+
 # import pprint
 import openai
 import prompts
 import conversation
 import constants
-from db import (
-    AppDB as appdb,
-    llm_responses as llmrdb,
-    summaries as s)
+from db import AppDB as appdb, llm_responses as llmrdb, summaries as s
 from tsutils import app_logging as al
 from tsutils import duration, utilities
 
@@ -19,30 +17,32 @@ logger = al.get_module_logger(al.GPT_RESPONDER_LOGGER)
 
 
 class InferenceEnum(Enum):
-    """Supported Chat Inference Providers
-    """
+    """Supported Chat Inference Providers"""
+
     OPENAI = 1
     TOGETHER = 2
 
 
 class GPTResponder:
-    """Handles all interactions with openAI LLM / ChatGPT
-    """
+    """Handles all interactions with openAI LLM / ChatGPT"""
+
     # By default we do not ping LLM to get data
     enabled: bool = False
     model: str = None
     llm_client = None
 
-    def __init__(self,
-                 config: dict,
-                 convo: conversation.Conversation,
-                 file_name: str,
-                 save_to_file: bool = False,
-                 openai_module=openai):
+    def __init__(
+        self,
+        config: dict,
+        convo: conversation.Conversation,
+        file_name: str,
+        save_to_file: bool = False,
+        openai_module=openai,
+    ):
         logger.info(GPTResponder.__name__)
         # This var is used by UI to populate the response textbox
         self.response = prompts.INITIAL_RESPONSE
-        self.llm_response_interval = config['General']['llm_response_interval']
+        self.llm_response_interval = config["General"]["llm_response_interval"]
         self.conversation = convo
         self.config = config
         self.save_response_to_file = save_to_file
@@ -51,37 +51,38 @@ class GPTResponder:
         self.streaming_complete = threading.Event()
 
     def summarize(self) -> str:
-        """Ping LLM to get a summary of the conversation.
-        """
+        """Ping LLM to get a summary of the conversation."""
         logger.info(GPTResponder.summarize.__name__)
 
-        chat_inference_provider = self.config['General']['chat_inference_provider']
-        if chat_inference_provider == 'openai':
-            settings_section = 'OpenAI'
-        elif chat_inference_provider == 'together':
-            settings_section = 'Together'
+        chat_inference_provider = self.config["General"]["chat_inference_provider"]
+        if chat_inference_provider == "openai":
+            settings_section = "OpenAI"
+        elif chat_inference_provider == "together":
+            settings_section = "Together"
 
-        api_key = self.config[settings_section]['api_key']
-        base_url = self.config[settings_section]['base_url']
-        model = self.config[settings_section]['ai_model']
+        api_key = self.config[settings_section]["api_key"]
+        base_url = self.config[settings_section]["base_url"]
+        model = self.config[settings_section]["ai_model"]
 
-        if not utilities.is_api_key_valid(api_key=api_key, base_url=base_url, model=model):
+        if not utilities.is_api_key_valid(
+            api_key=api_key, base_url=base_url, model=model
+        ):
             return None
 
-        with duration.Duration(name='OpenAI Summarize', screen=False):
-            timeout: int = self.config['OpenAI']['summarize_request_timeout_seconds']
-            temperature: float = self.config['OpenAI']['temperature']
+        with duration.Duration(name="OpenAI Summarize", screen=False):
+            timeout: int = self.config["OpenAI"]["summarize_request_timeout_seconds"]
+            temperature: float = self.config["OpenAI"]["temperature"]
             prompt_content = self.conversation.get_merged_conversation_summary()
             prompt_api_message = prompts.create_multiturn_prompt(prompt_content)
             last_convo_id = int(prompt_content[-1][2])
             # self._pretty_print_openai_request(prompt_api_message)
             summary_response = self.llm_client.chat.completions.create(
-                    model=self.model,
-                    messages=prompt_api_message,
-                    temperature=temperature,
-                    timeout=timeout,
-                    stream=True
-                )
+                model=self.model,
+                messages=prompt_api_message,
+                temperature=temperature,
+                timeout=timeout,
+                stream=True,
+            )
             collected_messages = ""
             for chunk in summary_response:
                 chunk_message = chunk.choices[0].delta  # extract the message
@@ -99,35 +100,35 @@ class GPTResponder:
 
     def _get_settings_section(self, provider: str) -> str:
         """Get the settings section based on the chat inference provider."""
-        if provider == 'openai':
-            return 'OpenAI'
-        elif provider == 'together':
-            return 'Together'
+        if provider == "openai":
+            return "OpenAI"
+        elif provider == "together":
+            return "Together"
         raise ValueError(f"Unsupported chat inference provider: {provider}")
 
     def _get_api_settings(self, settings_section: str):
         """Retrieve API settings from the configuration."""
-        api_key = self.config[settings_section]['api_key']
-        base_url = self.config[settings_section]['base_url']
-        model = self.config[settings_section]['ai_model']
+        api_key = self.config[settings_section]["api_key"]
+        base_url = self.config[settings_section]["base_url"]
+        model = self.config[settings_section]["ai_model"]
         return api_key, base_url, model
 
     def _get_openai_settings(self) -> (int, float):
         """Retrieve OpenAI-specific settings from the configuration."""
-        timeout = self.config['OpenAI']['response_request_timeout_seconds']
-        temperature = self.config['OpenAI']['temperature']
+        timeout = self.config["OpenAI"]["response_request_timeout_seconds"]
+        temperature = self.config["OpenAI"]["temperature"]
         return timeout, temperature
 
     def _get_llm_response(self, messages, temperature, timeout) -> str:
         """Send a request to the LLM and process the streaming response."""
         self.streaming_complete.clear()
-        with duration.Duration(name='OpenAI Chat Completion', screen=False):
+        with duration.Duration(name="OpenAI Chat Completion", screen=False):
             multi_turn_response = self.llm_client.chat.completions.create(
                 model=self.model,
                 messages=messages,
                 temperature=temperature,
                 timeout=timeout,
-                stream=True
+                stream=True,
             )
 
             collected_messages = ""
@@ -136,9 +137,18 @@ class GPTResponder:
                 if chunk_message.content:
                     message_text = chunk_message.content
                     collected_messages += message_text
-                    self._update_conversation(persona=constants.PERSONA_ASSISTANT,
-                                              response=collected_messages,
-                                              update_previous=True)
+                    self._update_conversation(
+                        persona=constants.PERSONA_ASSISTANT,
+                        response=collected_messages,
+                        update_previous=True,
+                    )
+                    ctx = self.conversation.context
+                    if (
+                        ctx.continuous_read
+                        and self.enabled
+                        and not ctx.update_response_now
+                    ):
+                        ctx.audio_player_var.enqueue_chunk(message_text)
             self.streaming_complete.set()
             return collected_messages
 
@@ -161,24 +171,33 @@ class GPTResponder:
         logger.info(GPTResponder.generate_response_from_transcript_no_check.__name__)
 
         try:
-            chat_inference_provider = self.config['General']['chat_inference_provider']
+            chat_inference_provider = self.config["General"]["chat_inference_provider"]
             settings_section = self._get_settings_section(chat_inference_provider)
             api_key, base_url, model = self._get_api_settings(settings_section)
 
-            if not utilities.is_api_key_valid(api_key=api_key, base_url=base_url, model=model):
+            if not utilities.is_api_key_valid(
+                api_key=api_key, base_url=base_url, model=model
+            ):
                 return None
 
             timeout, temperature = self._get_openai_settings()
-            multiturn_prompt_content = self.conversation.get_merged_conversation_response(
-                length=constants.MAX_TRANSCRIPTION_PHRASES_FOR_LLM)
+            multiturn_prompt_content = (
+                self.conversation.get_merged_conversation_response(
+                    length=constants.MAX_TRANSCRIPTION_PHRASES_FOR_LLM
+                )
+            )
             last_convo_id = int(multiturn_prompt_content[-1][2])
-            multiturn_prompt_api_message = prompts.create_multiturn_prompt(multiturn_prompt_content)
-            collected_messages = self._get_llm_response(multiturn_prompt_api_message, temperature, timeout)
+            multiturn_prompt_api_message = prompts.create_multiturn_prompt(
+                multiturn_prompt_content
+            )
+            collected_messages = self._get_llm_response(
+                multiturn_prompt_api_message, temperature, timeout
+            )
             self._insert_response_in_db(last_convo_id, collected_messages)
 
         except Exception as e:
             logger.error(f"Error in generate_response_from_transcript_no_check: {e}")
-            print(f'Error getting response from LLM: {e}')
+            print(f"Error getting response from LLM: {e}")
             return None
 
         self._save_response_to_file(collected_messages)
@@ -205,7 +224,9 @@ class GPTResponder:
         try:
             if self.llm_client is not None:
                 self.llm_client.close()
-            self.llm_client = self.openai_module.OpenAI(api_key=api_key, base_url=base_url)
+            self.llm_client = self.openai_module.OpenAI(
+                api_key=api_key, base_url=base_url
+            )
         except Exception as e:
             raise ConnectionError(f"Failed to create OpenAI client: {e}")
 
@@ -222,20 +243,20 @@ class GPTResponder:
         if input_str is None:
             raise ValueError("input_str cannot be None")
 
-        lines = input_str.split(sep='\n')
+        lines = input_str.split(sep="\n")
         response_lines = []
 
         for line in lines:
             # Skip any responses that contain content like
             # Speaker 1: <Some statement>
             # This is generated content added by OpenAI that can be skipped
-            if 'Speaker' in line and ':' in line:
+            if "Speaker" in line and ":" in line:
                 continue
-            response_lines.append(line.strip().strip('[').strip(']'))
+            response_lines.append(line.strip().strip("[").strip("]"))
 
         # Create a list and then use that to create a string for
         # performance reasons, since strings are immutable in python
-        response = ''.join(response_lines)
+        response = "".join(response_lines)
         return response
 
     def generate_response_from_transcript(self) -> str:
@@ -252,27 +273,31 @@ class GPTResponder:
         logger.info("generate_response_from_transcript called")
 
         if not self.enabled:
-            return ''
+            return ""
 
         return self.generate_response_from_transcript_no_check()
 
     def generate_response_for_selected_text(self, text: str):
         """Ping LLM to get a suggested response right away.
-            Gets a response even if the continuous suggestion option is disabled.
-            Updates the conversation object with the response from LLM.
+        Gets a response even if the continuous suggestion option is disabled.
+        Updates the conversation object with the response from LLM.
         """
         try:
             logger.info(GPTResponder.generate_response_for_selected_text.__name__)
-            chat_inference_provider = self.config['General']['chat_inference_provider']
+            chat_inference_provider = self.config["General"]["chat_inference_provider"]
             settings_section = self._get_settings_section(chat_inference_provider)
             api_key, base_url, model = self._get_api_settings(settings_section)
 
             timeout, temperature = self._get_openai_settings()
 
-            if not utilities.is_api_key_valid(api_key=api_key, base_url=base_url, model=model):
+            if not utilities.is_api_key_valid(
+                api_key=api_key, base_url=base_url, model=model
+            ):
                 return None
 
-            with duration.Duration(name='OpenAI Chat Completion Selected', screen=False):
+            with duration.Duration(
+                name="OpenAI Chat Completion Selected", screen=False
+            ):
                 self.streaming_complete.clear()
                 prompt = prompts.create_prompt_for_text(text=text, config=self.config)
                 llm_response = self.llm_client.chat.completions.create(
@@ -280,14 +305,16 @@ class GPTResponder:
                     messages=prompt,
                     temperature=temperature,
                     timeout=timeout,
-                    stream=True
+                    stream=True,
                 )
 
                 # Update conversation with an empty response. This response will be updated
                 # by subsequent updates from the streaming response
-                self._update_conversation(persona=constants.PERSONA_ASSISTANT,
-                                          response="  ",
-                                          update_previous=False)
+                self._update_conversation(
+                    persona=constants.PERSONA_ASSISTANT,
+                    response="  ",
+                    update_previous=False,
+                )
                 collected_messages = ""
                 for chunk in llm_response:
                     chunk_message = chunk.choices[0].delta  # extract the message
@@ -295,15 +322,17 @@ class GPTResponder:
                         message_text = chunk_message.content
                         collected_messages += message_text
                         # print(f"{message_text}", end="")
-                        self._update_conversation(persona=constants.PERSONA_ASSISTANT,
-                                                  response=collected_messages,
-                                                  update_previous=True)
+                        self._update_conversation(
+                            persona=constants.PERSONA_ASSISTANT,
+                            response=collected_messages,
+                            update_previous=True,
+                        )
                 self.streaming_complete.set()
 
         except Exception as exception:
-            print('Error when attempting to get a response from LLM.')
+            print("Error when attempting to get a response from LLM.")
             print(exception)
-            logger.error('Error when attempting to get a response from LLM.')
+            logger.error("Error when attempting to get a response from LLM.")
             logger.exception(exception)
             return prompts.INITIAL_RESPONSE
 
@@ -315,22 +344,23 @@ class GPTResponder:
 
     def _save_response_to_file(self, text: str):
         if self.save_response_to_file:
-            with open(file=self.response_file, mode="a", encoding='utf-8') as f:
-                f.write(f'{datetime.datetime.now()} - {text}\n')
+            with open(file=self.response_file, mode="a", encoding="utf-8") as f:
+                f.write(f"{datetime.datetime.now()} - {text}\n")
 
     def _update_conversation(self, response, persona, update_previous=False):
         """Update the internaal conversation state"""
         logger.info(GPTResponder._update_conversation.__name__)
-        if response != '':
+        if response != "":
             self.response = response
-            self.conversation.update_conversation(persona=persona,
-                                                  text=response,
-                                                  time_spoken=datetime.datetime.utcnow(),
-                                                  update_previous=update_previous)
+            self.conversation.update_conversation(
+                persona=persona,
+                text=response,
+                time_spoken=datetime.datetime.utcnow(),
+                update_previous=update_previous,
+            )
 
     def respond_to_transcriber(self, transcriber):
-        """Thread method to continously update the transcript
-        """
+        """Thread method to continously update the transcript"""
         while True:
 
             # Attempt to get responses only if transcript has changed
@@ -344,7 +374,9 @@ class GPTResponder:
                     self.generate_response_from_transcript()
 
                 end_time = time.time()  # Measure end time
-                execution_time = end_time - start_time  # Calculate time to execute the function
+                execution_time = (
+                    end_time - start_time
+                )  # Calculate time to execute the function
 
                 remaining_time = self.llm_response_interval - execution_time
                 if remaining_time > 0:
@@ -355,79 +387,86 @@ class GPTResponder:
                 time.sleep(self.llm_response_interval)
 
     def update_response_interval(self, interval):
-        """Change the interval for pinging LLM
-        """
+        """Change the interval for pinging LLM"""
         # Very chatty log statement
         # logger.info(GPTResponder.update_response_interval.__name__)
         self.llm_response_interval = interval
 
     def _pretty_print_openai_request(self, message: str):
         """Format the openAI request in a nice print format"""
-        print('[')
+        print("[")
         for item in message:
-            print('  {')
+            print("  {")
             print(f'    \'role\': \'{item["role"]}\'')
             print(f'    \'content\': \'{item["content"]}\'')
-            print('  }')
+            print("  }")
 
-        print(']')
+        print("]")
 
 
 class OpenAIResponder(GPTResponder):
     """Uses OpenAI for Chat Inference"""
 
-    def __init__(self,
-                 config: dict,
-                 convo: conversation.Conversation,
-                 response_file_name: str,
-                 save_to_file: bool = False,
-                 base_url: str = None):
+    def __init__(
+        self,
+        config: dict,
+        convo: conversation.Conversation,
+        response_file_name: str,
+        save_to_file: bool = False,
+        base_url: str = None,
+    ):
         logger.info(OpenAIResponder.__name__)
         self.config = config
-        api_key = self.config['OpenAI']['api_key']
-        base_url = self.config['OpenAI']['base_url']
+        api_key = self.config["OpenAI"]["api_key"]
+        base_url = self.config["OpenAI"]["base_url"]
         self.llm_client = openai.OpenAI(api_key=api_key, base_url=base_url)
-        self.model = self.config['OpenAI']['ai_model']
-        stt = self.config['General']['stt']
-        print(f'[INFO] Using {stt} for inference. Model: {self.model}')
-        super().__init__(config=self.config,
-                         convo=convo,
-                         save_to_file=save_to_file,
-                         file_name=response_file_name)
+        self.model = self.config["OpenAI"]["ai_model"]
+        stt = self.config["General"]["stt"]
+        print(f"[INFO] Using {stt} for inference. Model: {self.model}")
+        super().__init__(
+            config=self.config,
+            convo=convo,
+            save_to_file=save_to_file,
+            file_name=response_file_name,
+        )
 
 
 class TogetherAIResponder(GPTResponder):
     """Uses TogetherAI for Chat Inference"""
 
-    def __init__(self,
-                 config: dict,
-                 convo: conversation.Conversation,
-                 response_file_name: str,
-                 save_to_file: bool = False):
+    def __init__(
+        self,
+        config: dict,
+        convo: conversation.Conversation,
+        response_file_name: str,
+        save_to_file: bool = False,
+    ):
         logger.info(TogetherAIResponder.__name__)
         self.config = config
-        api_key = self.config['Together']['api_key']
-        base_url = self.config['Together']['base_url']
-        self.llm_client = openai.OpenAI(api_key=api_key,
-                                        base_url=base_url)
-        self.model = self.config['Together']['ai_model']
-        print(f'[INFO] Using Together AI for inference. Model: {self.model}')
-        super().__init__(config=self.config,
-                         convo=convo,
-                         save_to_file=save_to_file,
-                         file_name=response_file_name)
+        api_key = self.config["Together"]["api_key"]
+        base_url = self.config["Together"]["base_url"]
+        self.llm_client = openai.OpenAI(api_key=api_key, base_url=base_url)
+        self.model = self.config["Together"]["ai_model"]
+        print(f"[INFO] Using Together AI for inference. Model: {self.model}")
+        super().__init__(
+            config=self.config,
+            convo=convo,
+            save_to_file=save_to_file,
+            file_name=response_file_name,
+        )
 
 
 class InferenceResponderFactory:
-    """Factory class to get the appropriate Inference Provider / GPT Provider
-    """
-    def get_responder_instance(self,
-                               provider: InferenceEnum,
-                               config: dict,
-                               convo: conversation.Conversation,
-                               response_file_name: str,
-                               save_to_file: bool = False,
-                               ) -> GPTResponder:
+    """Factory class to get the appropriate Inference Provider / GPT Provider"""
+
+    def get_responder_instance(
+        self,
+        provider: InferenceEnum,
+        config: dict,
+        convo: conversation.Conversation,
+        response_file_name: str,
+        save_to_file: bool = False,
+    ) -> GPTResponder:
         """Get the appropriate Inference Provider class instance
         Args:
           provider: InferenceEnum: The Inference provider enum
@@ -437,21 +476,27 @@ class InferenceResponderFactory:
           response_file_name: str: Filename for saving LLM responses
         """
         if not isinstance(provider, InferenceEnum):
-            raise TypeError('InferenceResponderFactory: provider should be an instance of InferenceEnum')
+            raise TypeError(
+                "InferenceResponderFactory: provider should be an instance of InferenceEnum"
+            )
 
         if provider == InferenceEnum.OPENAI:
-            return OpenAIResponder(config=config,
-                                   convo=convo,
-                                   save_to_file=save_to_file,
-                                   response_file_name=response_file_name)
+            return OpenAIResponder(
+                config=config,
+                convo=convo,
+                save_to_file=save_to_file,
+                response_file_name=response_file_name,
+            )
         elif provider == InferenceEnum.TOGETHER:
-            return TogetherAIResponder(config=config,
-                                       convo=convo,
-                                       save_to_file=save_to_file,
-                                       response_file_name=response_file_name)
+            return TogetherAIResponder(
+                config=config,
+                convo=convo,
+                save_to_file=save_to_file,
+                response_file_name=response_file_name,
+            )
 
         raise ValueError("Unknown Inference Provider type")
 
 
 if __name__ == "__main__":
-    print('GPTResponder')
+    print("GPTResponder")

--- a/app/transcribe/tests/test_streaming_tts.py
+++ b/app/transcribe/tests/test_streaming_tts.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import MagicMock
+
+import sys
+import os
+from types import ModuleType
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+sys.modules["pyaudiowpatch"] = ModuleType("pyaudiowpatch")
+
+from app.transcribe.gpt_responder import GPTResponder
+
+
+class FakeChunk:
+    def __init__(self, text):
+        class Delta:
+            def __init__(self, content):
+                self.content = content
+
+        self.choices = [type("Obj", (), {"delta": Delta(text)})]
+
+
+class TestStreamingTTS(unittest.TestCase):
+    def setUp(self):
+        self.context = MagicMock()
+        self.context.continuous_read = True
+        self.context.update_response_now = False
+        self.context.audio_player_var = MagicMock()
+
+        self.convo = MagicMock()
+        self.convo.context = self.context
+        config = {
+            "General": {"llm_response_interval": 10, "continuous_response": True},
+            "OpenAI": {"response_lang": "english"},
+        }
+        self.responder = GPTResponder(
+            config=config, convo=self.convo, file_name="x", openai_module=MagicMock()
+        )
+        self.responder.enabled = True
+        self.responder.llm_client = MagicMock()
+        self.responder.model = "gpt"
+
+    def test_enqueue_chunks_when_streaming(self):
+        stream = [FakeChunk("Hello "), FakeChunk("world!")]
+        self.responder.llm_client.chat.completions.create.return_value = stream
+        result = self.responder._get_llm_response([], 0.5, 30)
+        self.assertEqual(result, "Hello world!")
+        calls = [
+            call.args[0]
+            for call in self.context.audio_player_var.enqueue_chunk.call_args_list
+        ]
+        self.assertEqual(calls, ["Hello ", "world!"])
+
+    def test_no_enqueue_when_manual(self):
+        self.context.update_response_now = True
+        stream = [FakeChunk("Hello "), FakeChunk("world!")]
+        self.responder.llm_client.chat.completions.create.return_value = stream
+        self.context.audio_player_var.enqueue_chunk.reset_mock()
+        self.responder._get_llm_response([], 0.5, 30)
+        self.assertFalse(self.context.audio_player_var.enqueue_chunk.called)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support streaming Text-To-Speech
- queue text chunks for immediate playback
- stop playback when toggles are disabled
- avoid duplicate audio when streaming
- test streaming TTS logic

## Testing
- `python3 -m py_compile app/transcribe/appui.py app/transcribe/audio_player.py app/transcribe/global_vars.py app/transcribe/gpt_responder.py app/transcribe/tests/test_streaming_tts.py`
- `black app/transcribe/appui.py app/transcribe/audio_player.py app/transcribe/global_vars.py app/transcribe/gpt_responder.py app/transcribe/tests/test_streaming_tts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842090bd0748321afc45ca336e20301