### PR TITLE
Fix streaming TTS buffering and disable speaker capture

### DIFF
--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -12,7 +12,8 @@ from gtts import gTTS
 import subprocess
 import sys
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from app.transcribe.audio_player import AudioPlayer
 import app.transcribe.conversation as c
 import app.transcribe.constants as const
@@ -28,13 +29,13 @@ class TestAudioPlayer(unittest.TestCase):
         self.convo.context.last_spoken_response = "initial"
         self.audio_player = AudioPlayer(convo=self.convo)
         self.config = {
-            'OpenAI': {'response_lang': 'english'},
-            'General': {'tts_speech_rate': 1.5},
-            'english': 'en'
+            "OpenAI": {"response_lang": "english"},
+            "General": {"tts_speech_rate": 1.5},
+            "english": "en",
         }
 
-    @patch('gtts.gTTS')
-    @patch('subprocess.Popen')
+    @patch("gtts.gTTS")
+    @patch("subprocess.Popen")
     def test_play_audio_exception(self, mock_popen, mock_gtts):
         """
         Test the play_audio method when an exception occurs.
@@ -42,15 +43,15 @@ class TestAudioPlayer(unittest.TestCase):
         Verifies that the method handles the playsound exception correctly and logs the error.
         """
         speech = "Hello, this is a test."
-        lang = 'en'
+        lang = "en"
         mock_gtts.return_value = MagicMock(spec=gTTS)
-        mock_popen.side_effect = Exception('ffplay missing')
+        mock_popen.side_effect = Exception("ffplay missing")
 
-        with self.assertLogs(level='ERROR') as log:
+        with self.assertLogs(level="ERROR") as log:
             self.audio_player.play_audio(speech, lang)
-            self.assertIn('Error when attempting to play audio.', log.output[0])
+            self.assertIn("Error when attempting to play audio.", log.output[0])
 
-    @patch.object(AudioPlayer, 'play_audio')
+    @patch.object(AudioPlayer, "play_audio")
     def test_play_audio_loop(self, mock_play_audio):
         """
         Test the play_audio_loop method.
@@ -59,7 +60,9 @@ class TestAudioPlayer(unittest.TestCase):
         """
         self.audio_player.read_response = True
         self.audio_player.speech_text_available.set()
-        self.convo.get_conversation.return_value = f"{const.PERSONA_ASSISTANT}: [Hello, this is a test.]"
+        self.convo.get_conversation.return_value = (
+            f"{const.PERSONA_ASSISTANT}: [Hello, this is a test.]"
+        )
 
         def side_effect(*args, **kwargs):
             self.audio_player.read_response = False
@@ -69,16 +72,28 @@ class TestAudioPlayer(unittest.TestCase):
         self.audio_player.speech_text_available.set()
         self.audio_player.read_response = True
 
-        thread = threading.Thread(target=self.audio_player.play_audio_loop, args=(self.config,))
+        thread = threading.Thread(
+            target=self.audio_player.play_audio_loop, args=(self.config,)
+        )
         thread.start()
 
         time.sleep(0.5)
 
-        self.assertFalse(self.audio_player.speech_text_available.is_set(), 'Threading Event was not cleared.')
-        self.assertFalse(self.audio_player.read_response, 'Read response boolean was not cleared.')
-        self.assertEqual(self.convo.context.last_spoken_response, 'initial',
-                         'Last spoken response should remain unchanged after playback.')
-        mock_play_audio.assert_called_once_with(speech="Hello, this is a test.", lang='en', rate=1.5)
+        self.assertFalse(
+            self.audio_player.speech_text_available.is_set(),
+            "Threading Event was not cleared.",
+        )
+        self.assertFalse(
+            self.audio_player.read_response, "Read response boolean was not cleared."
+        )
+        self.assertEqual(
+            self.convo.context.last_spoken_response,
+            "initial",
+            "Last spoken response should remain unchanged after playback.",
+        )
+        mock_play_audio.assert_called_once_with(
+            speech="Hello, this is a test.", lang="en", rate=1.5
+        )
         self.audio_player.stop_loop = True
 
     def test_get_language_code(self):
@@ -87,14 +102,20 @@ class TestAudioPlayer(unittest.TestCase):
 
         Verifies that the method correctly returns the language code from the configuration.
         """
-        lang_code = self.audio_player._get_language_code('english')  # pylint: disable=W0212
-        self.assertEqual(lang_code, 'en')
+        lang_code = self.audio_player._get_language_code(
+            "english"
+        )  # pylint: disable=W0212
+        self.assertEqual(lang_code, "en")
 
-        lang_code = self.audio_player._get_language_code('chinese')  # pylint: disable=W0212
-        self.assertEqual(lang_code, 'zh')
+        lang_code = self.audio_player._get_language_code(
+            "chinese"
+        )  # pylint: disable=W0212
+        self.assertEqual(lang_code, "zh")
 
-        lang_code = self.audio_player._get_language_code('bulgarian')  # pylint: disable=W0212
-        self.assertEqual(lang_code, 'bg')
+        lang_code = self.audio_player._get_language_code(
+            "bulgarian"
+        )  # pylint: disable=W0212
+        self.assertEqual(lang_code, "bg")
 
     def test_process_speech_text(self):
         """
@@ -104,9 +125,34 @@ class TestAudioPlayer(unittest.TestCase):
         and formatting.
         """
         speech = f"{const.PERSONA_ASSISTANT}: [Hello, this is a test.]"
-        processed_speech = self.audio_player._process_speech_text(speech)  # pylint: disable=W0212
+        processed_speech = self.audio_player._process_speech_text(
+            speech
+        )  # pylint: disable=W0212
         self.assertEqual(processed_speech, "Hello, this is a test.")
 
+    @patch.object(AudioPlayer, "play_audio")
+    def test_speaker_disabled_during_playback(self, mock_play_audio):
+        sp_rec = MagicMock()
+        sp_rec.enabled = True
+        self.convo.context.speaker_audio_recorder = sp_rec
+        self.audio_player.enqueue_chunk("hello")
 
-if __name__ == '__main__':
+        def check_disabled(*args, **kwargs):
+            self.assertFalse(sp_rec.enabled)
+
+        mock_play_audio.side_effect = check_disabled
+
+        thread = threading.Thread(
+            target=self.audio_player.play_audio_loop, args=(self.config,)
+        )
+        thread.start()
+        time.sleep(0.2)
+        self.audio_player.stop_loop = True
+        thread.join(timeout=1)
+
+        self.assertTrue(sp_rec.enabled)
+        mock_play_audio.assert_called_once_with(speech="hello", lang="en", rate=1.5)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- buffer TTS chunks so we don't speak one word at a time
- disable speaker capture while TTS plays
- update streaming tests for new buffering behavior
- test speaker capture disablement
- add mode tests for response/reading combinations

## Testing
- `python3 -m py_compile app/transcribe/audio_player.py app/transcribe/gpt_responder.py app/transcribe/tests/test_audio_player.py app/transcribe/tests/test_streaming_tts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420f54ee4483218c236ac2ca10d826