### PR TITLE
Improve real-time TTS streaming

### DIFF
--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -143,7 +143,7 @@ class AudioPlayer:
                 # can detect when a new response is generated and
                 # avoid replaying the same audio multiple times.
 
-            time.sleep(0.1)
+            time.sleep(0.01)
 
     def _get_language_code(self, lang: str) -> str:
         """Get the language code from the configuration."""

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -132,7 +132,6 @@ class GPTResponder:
             )
 
             collected_messages = ""
-            buffer = ""
             ctx = self.conversation.context
             for chunk in multi_turn_response:
                 chunk_message = chunk.choices[0].delta  # extract the message
@@ -149,17 +148,8 @@ class GPTResponder:
                         and self.enabled
                         and not ctx.update_response_now
                     ):
-                        buffer += message_text
-                        if len(buffer) >= 120 or buffer.endswith(tuple(".!?")):
-                            ctx.audio_player_var.enqueue_chunk(buffer.strip())
-                            buffer = ""
-            if (
-                ctx.continuous_read
-                and self.enabled
-                and not ctx.update_response_now
-                and buffer.strip()
-            ):
-                ctx.audio_player_var.enqueue_chunk(buffer.strip())
+                        ctx.audio_player_var.enqueue_chunk(message_text)
+
             self.streaming_complete.set()
             return collected_messages
 

--- a/app/transcribe/tests/test_real_time_tts_timing.py
+++ b/app/transcribe/tests/test_real_time_tts_timing.py
@@ -1,0 +1,55 @@
+import time
+import threading
+from unittest.mock import MagicMock
+
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.transcribe.audio_player import AudioPlayer
+from app.transcribe.global_vars import TranscriptionGlobals
+
+
+def test_real_time_tts_timing(monkeypatch):
+    ctx = TranscriptionGlobals()
+    ctx.audio_queue = MagicMock()
+    ctx.audio_queue.empty.return_value = True
+    ctx.speaker_audio_recorder = MagicMock()
+    ctx.speaker_audio_recorder.enabled = True
+
+    convo = MagicMock()
+    convo.context = ctx
+
+    player = AudioPlayer(convo)
+    timings = []
+
+    def fake_play_audio(speech, lang, rate):
+        timings.append((speech, time.time()))
+
+    monkeypatch.setattr(player, "play_audio", fake_play_audio)
+
+    config = {
+        "General": {"tts_speech_rate": 1.0},
+        "OpenAI": {"response_lang": "english"},
+    }
+
+    thread = threading.Thread(target=player.play_audio_loop, args=(config,))
+    thread.start()
+
+    start = time.time()
+    for chunk, delay in [("This is ", 0.0), ("a test ", 0.1), ("of streaming.", 0.2)]:
+        time.sleep(delay)
+        player.enqueue_chunk(chunk)
+
+    time.sleep(0.5)
+    player.stop_loop = True
+    thread.join(timeout=1)
+
+    arrival_times = [start + 0.0, start + 0.1, start + 0.2]
+    assert len(timings) == 3
+    for (speech, play_time), arrival in zip(timings, arrival_times):
+        assert play_time - arrival < 0.2
+
+    for i in range(1, len(timings)):
+        assert timings[i][1] - timings[i - 1][1] < 0.4

--- a/app/transcribe/tests/test_streaming_tts.py
+++ b/app/transcribe/tests/test_streaming_tts.py
@@ -40,13 +40,13 @@ class TestStreamingTTS(unittest.TestCase):
         self.responder.llm_client = MagicMock()
         self.responder.model = "gpt"
 
-    def test_enqueue_grouped_chunks_when_streaming(self):
+    def test_enqueue_chunks_when_streaming(self):
         stream = [FakeChunk("Hello "), FakeChunk("world! How "), FakeChunk("are you?")]
         self.responder.llm_client.chat.completions.create.return_value = stream
         result = self.responder._get_llm_response([], 0.5, 30)
         self.assertEqual(result, "Hello world! How are you?")
-        self.context.audio_player_var.enqueue_chunk.assert_called_once_with(
-            "Hello world! How are you?"
+        self.context.audio_player_var.enqueue_chunk.assert_has_calls(
+            [call("Hello "), call("world! How "), call("are you?")]
         )
 
     def test_no_enqueue_when_manual(self):
@@ -84,8 +84,8 @@ class TestStreamingTTS(unittest.TestCase):
         self.responder.llm_client.chat.completions.create.return_value = stream
         self.context.audio_player_var.enqueue_chunk.reset_mock()
         self.responder._get_llm_response([], 0.5, 30)
-        self.context.audio_player_var.enqueue_chunk.assert_called_once_with(
-            "Hello world!"
+        self.context.audio_player_var.enqueue_chunk.assert_has_calls(
+            [call("Hello "), call("world!")]
         )
 
 


### PR DESCRIPTION
## Summary
- stream TTS chunks immediately without buffering
- reduce loop delay for faster playback
- add regression test for streaming chunk order
- test timing to ensure playback keeps up with chunk arrival

## Testing
- `pip install pytest-timeout`
- `pip install playsound`
- `pip install gTTS==2.5.1`
- `apt-get install -y python3-pyaudio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684221d1ec28832187cca8274f18e9ea