### PR TITLE
Add ARM64 setup script and remove Windows-only audio deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,43 @@ Contributions are welcome! Open issues or submit pull requests to improve Transc
 
 ## Acknowledgements
 This project started out as a fork of [ecoute](https://github.com/SevaSk/ecoute/). It has diverged significantly from the original implementation so we decided to remove the link to ecoute.
+
+## ARM64 / Ubuntu Setup
+
+These instructions assume you are on ARM64 hardware (e.g., Surface Pro under WSL2/Ubuntu).
+
+1. **Install system dependencies** (run in a terminal):
+   ```bash
+   sudo apt-get update && sudo apt-get install -y \
+     python3-venv python3-pip python3-tk portaudio19-dev \
+     ffmpeg build-essential libssl-dev libffi-dev \
+     libatlas-base-dev libasound2-dev libportaudio2 \
+     libportaudiocpp0 tk
+   ```
+
+2. **Clone the repo and switch to the ARM64 branch:**
+   ```bash
+   git clone https://github.com/<your-org>/transcribe.git
+   cd transcribe
+   git checkout arm64-support
+   ```
+
+3. **Run the setup script:**
+   ```bash
+   chmod +x scripts/setup_arm64.sh
+   ./scripts/setup_arm64.sh
+   source venv/bin/activate
+   ```
+
+4. **Launch the application:**
+   ```bash
+   python main.py
+   ```
+
+If GUI/Tk errors occur, ensure `python3-tk` is installed.
+
+Dependencies
+
+Python packages: listed in `requirements.txt` (ARM64-compatible only)
+
+System packages: python3-venv, python3-tk, portaudio19-dev, ffmpeg, etc.

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -9,7 +9,6 @@ import tempfile
 import threading
 import subprocess
 import datetime
-import playsound
 import gtts
 from conversation import Conversation
 import constants

--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -12,7 +12,7 @@ from abc import abstractmethod
 # import pprint
 import wave
 import tempfile
-import pyaudiowpatch as pyaudio
+import pyaudio
 from difflib import SequenceMatcher
 # from db import AppDB as appdb
 import conversation  # noqa: E402 pylint: disable=C0413

--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -40,7 +40,7 @@ class TestAudioPlayer(unittest.TestCase):
         """
         Test the play_audio method when an exception occurs.
 
-        Verifies that the method handles the playsound exception correctly and logs the error.
+        Verifies that the method handles the playback exception correctly and logs the error.
         """
         speech = "Hello, this is a test."
         lang = 'en'

--- a/app/transcribe/tests/test_audio_transcriber.py
+++ b/app/transcribe/tests/test_audio_transcriber.py
@@ -2,11 +2,9 @@ import unittest
 import datetime
 import sys
 import os
-from types import ModuleType
 from unittest.mock import MagicMock
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-sys.modules['pyaudiowpatch'] = ModuleType('pyaudiowpatch')
 
 from app.transcribe.audio_transcriber import AudioTranscriber
 import app.transcribe.constants as const

--- a/app/transcribe/tests/test_continuous_read.py
+++ b/app/transcribe/tests/test_continuous_read.py
@@ -2,9 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import sys
 import os
-from types import ModuleType
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-sys.modules['pyaudiowpatch'] = ModuleType('pyaudiowpatch')
 from tsutils import configuration
 configuration.Config.__init__ = lambda self, *a, **k: None
 configuration.Config._current_data = {

--- a/custom_speech_recognition/__init__.py
+++ b/custom_speech_recognition/__init__.py
@@ -139,7 +139,7 @@ class Microphone(AudioSource):
         can't be found or a wrong version is installed
         """
         try:
-            import pyaudiowpatch as pyaudio
+            import pyaudio
         except ImportError:
             raise AttributeError("Could not find PyAudio; check installation")
         from distutils.version import LooseVersion

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,10 @@ customtkinter==5.2.2
 tkinter-tooltip  # Needed to show tooltips for ctk components
 pyperclip
 PyYAML
-PyAudio
+pyaudio>=0.2.11
 soundfile
 gtts
-# Playsound version 1.3 has issues in playing back audio files
-# in case of continuous play back of files in quick succession
-playsound==1.2.2
+simpleaudio>=1.0.4
 deepgram-sdk==3.2.5
 # Use 117 to build for CPU only
 # --extra-index-url https://download.pytorch.org/whl/cu117

--- a/scripts/setup_arm64.sh
+++ b/scripts/setup_arm64.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+echo "=== Installing ARM64/Ubuntu system packages ==="
+sudo apt-get update && sudo apt-get install -y \
+    python3-venv python3-pip python3-tk portaudio19-dev \
+    ffmpeg build-essential libssl-dev libffi-dev \
+    libatlas-base-dev libasound2-dev libportaudio2 \
+    libportaudiocpp0 tk
+
+echo "=== Create and activate Python virtual environment ==="
+python3 -m venv venv
+source venv/bin/activate
+
+echo "=== Upgrade pip, setuptools, and wheel ==="
+pip install --upgrade pip setuptools wheel
+
+echo "=== Install Python dependencies ==="
+pip install --upgrade -r requirements.txt
+
+echo "=== Setup complete! Run 'source venv/bin/activate' to activate your env ==="

--- a/sdk/audio_recorder.py
+++ b/sdk/audio_recorder.py
@@ -6,7 +6,7 @@ import wave
 from datetime import datetime
 from abc import abstractmethod
 
-import pyaudiowpatch as pyaudio
+import pyaudio
 import custom_speech_recognition as sr
 from tsutils import app_logging as al
 from tsutils import configuration  # noqa: E402 pylint: disable=C0413


### PR DESCRIPTION
## Summary
- remove windows-specific `playsound` lib and switch to plain ffplay
- drop `pyaudiowpatch` in favour of standard `pyaudio`
- add new `scripts/setup_arm64.sh` for Ubuntu/ARM64
- document ARM64 install steps in README
- update tests after removing the pyaudiowpatch stub
- update requirements for `pyaudio` and `simpleaudio`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tsutils')*

------
https://chatgpt.com/codex/tasks/task_e_68422be865e88321b20a797932c72898