### PR TITLE
Handle mic init errors on WSLg

### DIFF
--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -144,8 +144,8 @@ def create_transcriber(
             stt_model_config=stt_model_config)
 
         t = DeepgramTranscriber(
-            global_vars.user_audio_recorder.source,
-            global_vars.speaker_audio_recorder.source,
+            global_vars.user_audio_recorder.source if global_vars.user_audio_recorder else None,
+            global_vars.speaker_audio_recorder.source if global_vars.speaker_audio_recorder else None,
             model,
             convo=global_vars.convo,
             config=config)
@@ -158,8 +158,8 @@ def create_transcriber(
             stt_model=tm.STTEnum.WHISPER_CPP,
             stt_model_config=stt_model_config)
         t = WhisperCPPTranscriber(
-            global_vars.user_audio_recorder.source,
-            global_vars.speaker_audio_recorder.source,
+            global_vars.user_audio_recorder.source if global_vars.user_audio_recorder else None,
+            global_vars.speaker_audio_recorder.source if global_vars.speaker_audio_recorder else None,
             model,
             convo=global_vars.convo,
             config=config)
@@ -173,8 +173,8 @@ def create_transcriber(
             stt_model=tm.STTEnum.WHISPER_LOCAL,
             stt_model_config=stt_model_config)
         t = WhisperTranscriber(
-            global_vars.user_audio_recorder.source,
-            global_vars.speaker_audio_recorder.source,
+            global_vars.user_audio_recorder.source if global_vars.user_audio_recorder else None,
+            global_vars.speaker_audio_recorder.source if global_vars.speaker_audio_recorder else None,
             model,
             convo=global_vars.convo,
             config=config)
@@ -188,8 +188,8 @@ def create_transcriber(
             stt_model=tm.STTEnum.WHISPER_API,
             stt_model_config=stt_model_config)
         t = WhisperTranscriber(
-            global_vars.user_audio_recorder.source,
-            global_vars.speaker_audio_recorder.source,
+            global_vars.user_audio_recorder.source if global_vars.user_audio_recorder else None,
+            global_vars.speaker_audio_recorder.source if global_vars.speaker_audio_recorder else None,
             model,
             convo=global_vars.convo,
             config=config)
@@ -212,6 +212,8 @@ def get_language_code(lang: str) -> str:
 def shutdown(global_vars: TranscriptionGlobals):
     """Activities to be performed right before application shutdown.
     """
-    global_vars.user_audio_recorder.write_wav_data_to_file()
-    global_vars.speaker_audio_recorder.write_wav_data_to_file()
+    if global_vars.user_audio_recorder:
+        global_vars.user_audio_recorder.write_wav_data_to_file()
+    if global_vars.speaker_audio_recorder:
+        global_vars.speaker_audio_recorder.write_wav_data_to_file()
     AppDB().shutdown_app()

--- a/app/transcribe/appui.py
+++ b/app/transcribe/appui.py
@@ -435,9 +435,10 @@ class AppUI(ctk.CTk):
         """Toggles the state of speaker
         """
         try:
-            self.global_vars.speaker_audio_recorder.enabled = not self.global_vars.speaker_audio_recorder.enabled
-            self.editmenu.entryconfigure(2, label="Disable Speaker" if self.global_vars.speaker_audio_recorder.enabled else "Enable Speaker")
-            self.capture_action(f'{"Enabled " if self.global_vars.speaker_audio_recorder.enabled else "Disabled "} speaker input')
+            if self.global_vars.speaker_audio_recorder:
+                self.global_vars.speaker_audio_recorder.enabled = not self.global_vars.speaker_audio_recorder.enabled
+                self.editmenu.entryconfigure(2, label="Disable Speaker" if self.global_vars.speaker_audio_recorder.enabled else "Enable Speaker")
+                self.capture_action(f'{"Enabled " if self.global_vars.speaker_audio_recorder.enabled else "Disabled "} speaker input')
         except Exception as e:
             logger.error(f"Error toggling speaker state: {e}")
 
@@ -445,9 +446,10 @@ class AppUI(ctk.CTk):
         """Toggles the state of microphone
         """
         try:
-            self.global_vars.user_audio_recorder.enabled = not self.global_vars.user_audio_recorder.enabled
-            self.editmenu.entryconfigure(3, label="Disable Microphone" if self.global_vars.user_audio_recorder.enabled else "Enable Microphone")
-            self.capture_action(f'{"Enabled " if self.global_vars.user_audio_recorder.enabled else "Disabled "} microphone input')
+            if self.global_vars.user_audio_recorder:
+                self.global_vars.user_audio_recorder.enabled = not self.global_vars.user_audio_recorder.enabled
+                self.editmenu.entryconfigure(3, label="Disable Microphone" if self.global_vars.user_audio_recorder.enabled else "Enable Microphone")
+                self.capture_action(f'{"Enabled " if self.global_vars.user_audio_recorder.enabled else "Disabled "} microphone input')
         except Exception as e:
             logger.error(f"Error toggling microphone state: {e}")
 

--- a/app/transcribe/args.py
+++ b/app/transcribe/args.py
@@ -169,13 +169,13 @@ def update_audio_devices(global_vars: TranscriptionGlobals, config: dict):
     """Handle all application configuration using the command line args"""
 
     # Handle mic if it is not disabled in arguments or yaml file
-    if not config['General']['disable_mic']:
+    if not config['General']['disable_mic'] and global_vars.user_audio_recorder:
         if config['General']['mic_device_index'] != -1:
             print('[INFO] Override default microphone with device specified in parameters file.')
             global_vars.user_audio_recorder.set_device(index=int(config['General']['mic_device_index']))
 
     # Handle speaker if it is not disabled in arguments or yaml file
-    if not config['General']['disable_speaker']:
+    if not config['General']['disable_speaker'] and global_vars.speaker_audio_recorder:
         if config['General']['speaker_device_index'] != -1:
             print('[INFO] Override default speaker with device specified in parameters file.')
             global_vars.user_audio_recorder.set_device(index=int(config['General']['speaker_device_index']))

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -105,14 +105,16 @@ class AudioPlayer:
 
                 if new_text:
                     sp_rec = gv.speaker_audio_recorder
-                    prev_sp_state = sp_rec.enabled
-                    sp_rec.enabled = False
+                    prev_sp_state = sp_rec.enabled if sp_rec else False
+                    if sp_rec:
+                        sp_rec.enabled = False
                     try:
                         gv.last_spoken_response += new_text
                         self.play_audio(speech=new_text, lang=lang_code, rate=rate)
                     finally:
                         time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
-                        sp_rec.enabled = prev_sp_state
+                        if sp_rec:
+                            sp_rec.enabled = prev_sp_state
                         gv.last_playback_end = datetime.datetime.utcnow()
                 elif gv.responder.streaming_complete.is_set():
                     self.read_response = False
@@ -132,8 +134,9 @@ class AudioPlayer:
                 sp_rec = gv.speaker_audio_recorder
                 # Only disable speaker capture so user mic remains active and
                 # playback can be interrupted by new speech.
-                prev_sp_state = sp_rec.enabled
-                sp_rec.enabled = False
+                prev_sp_state = sp_rec.enabled if sp_rec else False
+                if sp_rec:
+                    sp_rec.enabled = False
                 gv = self.conversation.context
                 try:
                     if gv.real_time_read:
@@ -148,7 +151,8 @@ class AudioPlayer:
                         self.play_audio(speech=final_speech, lang=lang_code, rate=rate)
                 finally:
                     time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
-                    sp_rec.enabled = prev_sp_state
+                    if sp_rec:
+                        sp_rec.enabled = prev_sp_state
                     gv.last_playback_end = datetime.datetime.utcnow()
 
                     # Reset last_spoken_response so any queued text is cleared

--- a/app/transcribe/conftest.py
+++ b/app/transcribe/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+TEST_DIR = os.path.dirname(__file__)
+# Add transcribe package and project root for imports
+sys.path.insert(0, os.path.abspath(TEST_DIR))
+sys.path.insert(0, os.path.abspath(os.path.join(TEST_DIR, '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(TEST_DIR, '..', '..')))

--- a/app/transcribe/main.py
+++ b/app/transcribe/main.py
@@ -30,8 +30,18 @@ def main():
                           config=config,
                           api=bool(config['General']['use_api']),
                           global_vars=global_vars)
-    global_vars.transcriber.set_source_properties(mic_source=global_vars.user_audio_recorder.source,
-                                                  speaker_source=global_vars.speaker_audio_recorder.source)
+    if global_vars.user_audio_recorder:
+        mic_source = global_vars.user_audio_recorder.source
+    else:
+        mic_source = None
+
+    if global_vars.speaker_audio_recorder:
+        speaker_source = global_vars.speaker_audio_recorder.source
+    else:
+        speaker_source = None
+
+    global_vars.transcriber.set_source_properties(mic_source=mic_source,
+                                                  speaker_source=speaker_source)
 
     # Remove potential temp files from previous invocation
     data_dir = u.get_data_path(app_name='Transcribe')
@@ -44,13 +54,15 @@ def main():
     # Convert raw audio files to real wav file format when program exits
     atexit.register(au.shutdown, global_vars)
 
-    user_stop_func = global_vars.user_audio_recorder.record_audio(global_vars.audio_queue)
-    global_vars.user_audio_recorder.stop_record_func = user_stop_func
+    if global_vars.user_audio_recorder:
+        user_stop_func = global_vars.user_audio_recorder.record_audio(global_vars.audio_queue)
+        global_vars.user_audio_recorder.stop_record_func = user_stop_func
 
     time.sleep(2)
 
-    speaker_stop_func = global_vars.speaker_audio_recorder.record_audio(global_vars.audio_queue)
-    global_vars.speaker_audio_recorder.stop_record_func = speaker_stop_func
+    if global_vars.speaker_audio_recorder:
+        speaker_stop_func = global_vars.speaker_audio_recorder.record_audio(global_vars.audio_queue)
+        global_vars.speaker_audio_recorder.stop_record_func = speaker_stop_func
 
     # Transcriber needs to be created before handling batch tasks which include batch
     # transcription. This order of initialization results in initialization of Mic, Speaker

--- a/app/transcribe/tests/conftest.py
+++ b/app/transcribe/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+TEST_DIR = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(os.path.join(TEST_DIR, '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(TEST_DIR, '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(TEST_DIR, '..', '..', '..')))

--- a/app/transcribe/tests/test_global_vars_audio.py
+++ b/app/transcribe/tests/test_global_vars_audio.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import importlib.util
+
+test_dir = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(os.path.join(test_dir, '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(test_dir, '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(test_dir, '..', '..', '..')))
+
+from tsutils import configuration
+configuration.Config.__init__ = lambda self, *a, **k: None
+configuration.Config._current_data = {
+    'General': {
+        'disable_mic': False,
+        'mic_device_index': -1,
+        'disable_speaker': False,
+        'speaker_device_index': -1,
+        'llm_response_interval': 10,
+        'system_prompt': 'test',
+        'initial_convo': {}
+    },
+    'OpenAI': {'audio_lang': 'english', 'response_lang': 'english'}
+}
+module_path = os.path.join(test_dir, '..', 'global_vars.py')
+sys.path.insert(0, os.path.abspath(os.path.join(test_dir, '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(test_dir, '..', '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(test_dir, '..', '..', '..')))
+spec = importlib.util.spec_from_file_location('global_vars', module_path)
+gv_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gv_mod)
+TranscriptionGlobals = gv_mod.TranscriptionGlobals
+import pytest
+
+
+def test_initiate_audio_devices_skips_on_wsl_error(monkeypatch, tmp_path):
+    import sdk.audio_recorder as ar
+    # Simulate MicRecorder raising an exception when instantiated
+    def _raise(*args, **kwargs):
+        raise Exception("no device")
+    monkeypatch.setattr(ar, 'MicRecorder', _raise)
+    gv = TranscriptionGlobals()
+    config = {'General': {'disable_mic': False,
+                          'mic_device_index': -1,
+                          'disable_speaker': False,
+                          'speaker_device_index': -1}}
+    gv.initiate_audio_devices(config)
+    assert gv.user_audio_recorder is None
+    assert gv.speaker_audio_recorder is None


### PR DESCRIPTION
## Summary
- gracefully handle microphone initialization on WSLg
- guard app usage of recorders when not available
- ensure shutdown only writes audio when recorders exist
- add pytest config helpers for import paths
- add unit test for failed mic init

## Testing
- `pytest app/transcribe/tests/test_global_vars_audio.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68447f20c7608321993571d91f097536