### PR TITLE
Fix speaker recorder initialization

### DIFF
--- a/app/transcribe/global_vars.py
+++ b/app/transcribe/global_vars.py
@@ -19,7 +19,7 @@ class TranscriptionGlobals(Singleton.Singleton):
 
     audio_queue: queue.Queue = None
     user_audio_recorder: ar.MicRecorder = None
-    speaker_audio_recorder: ar.MicRecorder = None
+    speaker_audio_recorder: ar.SpeakerRecorder = None
     audio_player_var: audio_player.AudioPlayer = None
     # Global for transcription from speaker, microphone
     transcriber: AudioTranscriber = None
@@ -115,7 +115,9 @@ class TranscriptionGlobals(Singleton.Singleton):
         # Handle speaker if it is not disabled in arguments or yaml file
         print('[INFO] Using default speaker.')
         try:
-            self.speaker_audio_recorder = ar.MicRecorder(audio_file_name=f'{data_dir}/logs/sp.wav', is_speaker=True)
+            self.speaker_audio_recorder = ar.SpeakerRecorder(
+                audio_file_name=f'{data_dir}/logs/speaker.wav'
+            )
         except Exception as e:
             logger.warning(f"Could not initialize speaker recorder: {e}")
             self.speaker_audio_recorder = None

--- a/app/transcribe/tests/test_global_vars_audio.py
+++ b/app/transcribe/tests/test_global_vars_audio.py
@@ -34,10 +34,11 @@ import pytest
 
 def test_initiate_audio_devices_skips_on_wsl_error(monkeypatch, tmp_path):
     import sdk.audio_recorder as ar
-    # Simulate MicRecorder raising an exception when instantiated
+    # Simulate recorders raising an exception when instantiated
     def _raise(*args, **kwargs):
         raise Exception("no device")
     monkeypatch.setattr(ar, 'MicRecorder', _raise)
+    monkeypatch.setattr(ar, 'SpeakerRecorder', _raise)
     gv = TranscriptionGlobals()
     config = {'General': {'disable_mic': False,
                           'mic_device_index': -1,


### PR DESCRIPTION
## Summary
- use SpeakerRecorder to capture speaker output
- keep SpeakerRecorder type annotation for globals
- update tests for the new recorder

## Testing
- `python3 app/transcribe/main.py -dm -ds` *(fails: 'NoneType' object has no attribute 'SAMPLE_RATE')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448945910c83219931157da23fc5ea