### PR TITLE
Handle None mic source in WhisperTranscriber

### DIFF
--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -177,7 +177,12 @@ def create_transcriber(
             global_vars.speaker_audio_recorder.source if global_vars.speaker_audio_recorder else None,
             model,
             convo=global_vars.convo,
-            config=config)
+            config=config,
+            source_name=(
+                global_vars.user_audio_recorder.source_name
+                if global_vars.user_audio_recorder else "Microphone"
+            )
+        )
     elif name.lower() == 'whisper' and api:
         stt_model_config: dict = {
             'api_key': config['OpenAI']['api_key'],
@@ -192,7 +197,12 @@ def create_transcriber(
             global_vars.speaker_audio_recorder.source if global_vars.speaker_audio_recorder else None,
             model,
             convo=global_vars.convo,
-            config=config)
+            config=config,
+            source_name=(
+                global_vars.user_audio_recorder.source_name
+                if global_vars.user_audio_recorder else "Microphone"
+            )
+        )
     else:
         raise ValueError(f'Unknown transcriber: {name}')
     global_vars.set_transcriber(t)

--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -426,6 +426,16 @@ class WhisperTranscriber(AudioTranscriber):
     Also processes the local application state as it relates to Whisper.
     Does not interact with the Whisper API or Local Whisper SDK.
     """
+    def __init__(self, mic_source, speaker_source, model,
+                 convo: conversation.Conversation, config: dict,
+                 source_name: str):
+        if mic_source is None:
+            raise ValueError(
+                f"Audio source '{source_name}' not found. Please configure a valid microphone source."  # noqa: E501
+            )
+        self.sample_rate = mic_source.SAMPLE_RATE
+        super().__init__(mic_source, speaker_source, model, convo, config)
+
     def check_for_latency(self, results: dict) -> tuple[bool, int, float]:
         """Very long audio clips can result in latency of transcription.
         Prune long audio clips based on number of segments, audio duration.

--- a/tests/test_audio_transcriber.py
+++ b/tests/test_audio_transcriber.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+BASE_DIR = os.path.join(os.path.dirname(__file__), '..')
+sys.path.append(BASE_DIR)
+sys.path.append(os.path.join(BASE_DIR, 'app', 'transcribe'))
+
+from app.transcribe.audio_transcriber import WhisperTranscriber
+
+
+def _basic_config():
+    return {
+        'General': {
+            'clear_transcript_periodically': False,
+            'clear_transcript_interval_seconds': 10
+        }
+    }
+
+
+def make_mocks():
+    mic = MagicMock()
+    mic.SAMPLE_RATE = 16000
+    mic.SAMPLE_WIDTH = 2
+    mic.channels = 1
+
+    speaker = MagicMock()
+    speaker.SAMPLE_RATE = 16000
+    speaker.SAMPLE_WIDTH = 2
+    speaker.channels = 1
+
+    model = MagicMock()
+    convo = MagicMock()
+    convo.context = MagicMock()
+
+    return mic, speaker, model, convo
+
+
+# Test Case 1
+def test_whisper_transcriber_initializes_sample_rate():
+    mic, speaker, model, convo = make_mocks()
+    config = _basic_config()
+
+    transcriber = WhisperTranscriber(mic, speaker, model, convo, config, source_name='mic')
+
+    assert transcriber.sample_rate == 16000
+
+
+# Test Case 2
+def test_whisper_transcriber_missing_source_raises():
+    _, speaker, model, convo = make_mocks()
+    config = _basic_config()
+
+    with pytest.raises(ValueError) as exc:
+        WhisperTranscriber(None, speaker, model, convo, config, source_name='dummy')
+
+    assert "Audio source 'dummy' not found" in str(exc.value)
+


### PR DESCRIPTION
## Summary
- guard WhisperTranscriber against missing mic source
- pass microphone name when creating WhisperTranscriber
- test WhisperTranscriber initialization with and without mic source

## Testing
- `pytest tests/test_audio_transcriber.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a7ecf0a48321ad750d68f1760a2e