### PR TITLE
Implement adjustable TTS volume

### DIFF
--- a/app/transcribe/appui.py
+++ b/app/transcribe/appui.py
@@ -147,6 +147,19 @@ class AppUI(ctk.CTk):
         self.word_cloud_button.grid(row=4, column=4, padx=10, pady=3, sticky="nsew")
         self.word_cloud_button.configure(command=self.word_cloud)
 
+        # TTS volume label and slider
+        self.tts_volume_label = ctk.CTkLabel(self.bottom_frame, text="", font=("Arial", 12),
+                                             text_color="#FFFCF2")
+        self.tts_volume_label.grid(row=4, column=0, columnspan=4, padx=10, pady=3, sticky="nsew")
+
+        self.tts_volume_slider = ctk.CTkSlider(self.bottom_frame, from_=0, to=100, width=300)
+        self.tts_volume_slider.set(config['General'].get('tts_playback_volume', 0.5) * 100)
+        self.tts_volume_slider.grid(row=5, column=0, columnspan=4, padx=10, pady=3, sticky="nsew")
+        self.tts_volume_slider.configure(command=self.update_tts_volume)
+
+        volume_text = f'TTS Volume: {int(self.tts_volume_slider.get())}%'
+        self.tts_volume_label.configure(text=volume_text)
+
         # Continuous read aloud switch
         read_enabled = bool(config['General'].get('continuous_read', False))
         self.continuous_read_button = ctk.CTkSwitch(self.bottom_frame, text="Read Responses Continuously")
@@ -466,6 +479,19 @@ class AppUI(ctk.CTk):
             self.capture_action(f'Update LLM response interval to {int(slider_value)}')
         except Exception as e:
             logger.error(f"Error updating slider value: {e}")
+
+    def update_tts_volume(self, slider_value):
+        """Update TTS playback volume in real-time and save to config"""
+        try:
+            config_obj = configuration.Config()
+            volume_level = float(slider_value) / 100
+            altered_config = {'General': {'tts_playback_volume': volume_level}}
+            config_obj.add_override_value(altered_config)
+            self.tts_volume_label.configure(text=f'TTS Volume: {int(float(slider_value))}%')
+            self.global_vars.audio_player_var.tts_volume = volume_level
+            self.capture_action(f'Update TTS volume to {int(float(slider_value))}%')
+        except Exception as e:
+            logger.error(f"Error updating TTS volume: {e}")
 
     def get_response_now(self):
         """Get response from LLM right away

--- a/app/transcribe/audio_player.py
+++ b/app/transcribe/audio_player.py
@@ -33,6 +33,7 @@ class AudioPlayer:
         self.current_process = None
         self.play_lock = threading.Lock()
         self.speech_rate = constants.DEFAULT_TTS_SPEECH_RATE
+        self.tts_volume = constants.DEFAULT_TTS_VOLUME
 
     def stop_current_playback(self):
         """Stop any current audio playback"""
@@ -47,7 +48,8 @@ class AudioPlayer:
                     pass
         self.current_process = None
 
-    def play_audio(self, speech: str, lang: str, rate: float | None = None):
+    def play_audio(self, speech: str, lang: str, rate: float | None = None,
+                   volume: float | None = None):
         """Play text as audio.
         This is a blocking method and will return when audio playback is complete.
         For large audio text, this could take several minutes.
@@ -62,8 +64,13 @@ class AudioPlayer:
             with self.play_lock:
                 self.stop_current_playback()
                 cmd = ['ffplay', '-nodisp', '-autoexit', '-loglevel', 'quiet']
+                filters = []
                 if rate and rate != 1.0:
-                    cmd += ['-af', f'atempo={rate}']
+                    filters.append(f'atempo={rate}')
+                if volume is not None and volume != 1.0:
+                    filters.append(f'volume={volume}')
+                if filters:
+                    cmd += ['-af', ','.join(filters)]
                 cmd.append(temp_audio_file[1])
                 self.current_process = subprocess.Popen(
                     cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -88,6 +95,8 @@ class AudioPlayer:
         lang_code = self._get_language_code(lang)
         rate = config.get('General', {}).get('tts_speech_rate', self.speech_rate)
         self.speech_rate = rate
+        volume = config.get('General', {}).get('tts_playback_volume', self.tts_volume)
+        self.tts_volume = volume
 
         while self.stop_loop is False:
             if self.speech_text_available.is_set() and self.read_response:
@@ -108,7 +117,8 @@ class AudioPlayer:
                 prev_sp_state = sp_rec.enabled
                 sp_rec.enabled = False
                 try:
-                    self.play_audio(speech=final_speech, lang=lang_code, rate=rate)
+                    self.play_audio(speech=final_speech, lang=lang_code,
+                                   rate=rate, volume=volume)
                 finally:
                     time.sleep(constants.SPEAKER_REENABLE_DELAY_SECONDS)
                     sp_rec.enabled = prev_sp_state

--- a/app/transcribe/constants.py
+++ b/app/transcribe/constants.py
@@ -18,3 +18,5 @@ PLAYBACK_IGNORE_WINDOW_SECONDS = 2.0
 IGNORE_SIMILARITY_THRESHOLD = 0.85
 # Default speech rate for TTS output (1.0 is normal speed)
 DEFAULT_TTS_SPEECH_RATE = 1.3
+# Default volume for TTS playback (1.0 is 100%)
+DEFAULT_TTS_VOLUME = 0.5

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -87,6 +87,8 @@ General:
   llm_response_interval: 10
   # Playback speed for read-aloud responses
   tts_speech_rate: 1.3
+  # Volume level for read-aloud responses (0.0 to 1.0)
+  tts_playback_volume: 0.5
 
 # This is equivalent to -c argument on command line
 # Command line argument takes precedence over value specified in parameters.yaml

--- a/app/transcribe/tests/test_audio_player.py
+++ b/app/transcribe/tests/test_audio_player.py
@@ -29,7 +29,7 @@ class TestAudioPlayer(unittest.TestCase):
         self.audio_player = AudioPlayer(convo=self.convo)
         self.config = {
             'OpenAI': {'response_lang': 'english'},
-            'General': {'tts_speech_rate': 1.5},
+            'General': {'tts_speech_rate': 1.5, 'tts_playback_volume': 0.5},
             'english': 'en'
         }
 
@@ -78,7 +78,7 @@ class TestAudioPlayer(unittest.TestCase):
         self.assertFalse(self.audio_player.read_response, 'Read response boolean was not cleared.')
         self.assertEqual(self.convo.context.last_spoken_response, 'initial',
                          'Last spoken response should remain unchanged after playback.')
-        mock_play_audio.assert_called_once_with(speech="Hello, this is a test.", lang='en', rate=1.5)
+        mock_play_audio.assert_called_once_with(speech="Hello, this is a test.", lang='en', rate=1.5, volume=0.5)
         self.audio_player.stop_loop = True
 
     def test_get_language_code(self):

--- a/app/transcribe/tests/test_tts_volume_config.py
+++ b/app/transcribe/tests/test_tts_volume_config.py
@@ -1,0 +1,29 @@
+import unittest
+import yaml
+import tempfile
+import os
+
+
+class TestTTSVolumeConfig(unittest.TestCase):
+    def test_tts_volume_setting(self):
+        with open('app/transcribe/parameters.yaml', 'r', encoding='utf-8') as f:
+            config = yaml.safe_load(f)
+        self.assertIn('tts_playback_volume', config['General'])
+        self.assertGreaterEqual(config['General']['tts_playback_volume'], 0)
+        self.assertLessEqual(config['General']['tts_playback_volume'], 1)
+
+        fd, temp_name = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            yaml.dump(config, open(temp_name, 'w', encoding='utf-8'))
+            config['General']['tts_playback_volume'] = 0.3
+            yaml.dump(config, open(temp_name, 'w', encoding='utf-8'))
+            with open(temp_name, 'r', encoding='utf-8') as f:
+                updated = yaml.safe_load(f)
+            self.assertEqual(updated['General']['tts_playback_volume'], 0.3)
+        finally:
+            os.remove(temp_name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new constant `DEFAULT_TTS_VOLUME`
- support `tts_playback_volume` in AudioPlayer and YAML configuration
- expose volume slider in the UI
- save updated volume to `override.yaml` when changed
- update unit tests and add test for volume config

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b1da9a88832182c1a234e0c9f1aa